### PR TITLE
Stats consistency: Games-Howell, Welch ANOVA, drop pingouin

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"74a00519-715a-4320-b8eb-06f1e90637fa","pid":3712889,"procStart":"15086839","acquiredAt":1780550558444}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ data = pd.read_csv("data.csv")
 result = stat.allstats(data)
 # result = stat.allstats(data, p_adj=False) # When you don't want to adjust p-value
 
+# For 3+ groups you can choose the ANOVA variance assumption and the parametric
+# post-hoc test explicitly (the non-parametric Dunn post-hoc is always included):
+# result = stat.allstats(data, anova_use_var="unequal")           # Welch's ANOVA
+# result = stat.allstats(data, posthoc="games_howell")            # Games-Howell instead of Scheffé
+# result = stat.allstats(data, posthoc="both")                    # both Scheffé and Games-Howell
+
 result.to_csv('result.csv', index=False)  # Save the result as a csv file
 ```
 
@@ -92,6 +98,12 @@ stats_res = stat.allstats(data)
 
 plot.plot_box(data, stats_res, test_type="t-test")
 plot.plot_bar(data, stats_res, test_type="t-test")
+
+# test_type selects which p-value column drives the significance brackets:
+# "t-test", "u-test", "scheffe", "games_howell" (3+ groups), or "dunn".
+# Use the same post-hoc you requested in allstats(); e.g. for games_howell:
+# stats_res = stat.allstats(data, posthoc="games_howell")
+# plot.plot_box(data, stats_res, test_type="games_howell")
 
 # plot only significant metabolites for the selected test (default alpha=0.05)
 # plot.plot_box(data, stats_res, test_type="t-test", significant_only=True)

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -406,7 +406,7 @@ def _plot_multi(
         Statistics table. Index = variables, columns include p-value columns.
     kind : {"box", "bar"}
         Type of plot for each variable.
-    test_type : {"t-test", "u-test", "scheffe", "dunn"}
+    test_type : {"t-test", "u-test", "scheffe", "games_howell", "dunn"}
         Which p-value column to pick in `stats_res`.
     significant_only : bool
         If True, plot only variables with at least one p-value <= `alpha`
@@ -428,9 +428,9 @@ def _plot_multi(
     if kind not in _KIND:
         raise ValueError("kind must be 'box' or 'bar'.")
 
-    if test_type.lower() not in ("t-test", "u-test", "scheffe", "dunn"):
+    if test_type.lower() not in ("t-test", "u-test", "scheffe", "games_howell", "dunn"):
         raise ValueError(
-            "test_type must be 't-test', 'u-test', 'scheffe', or 'dunn'."
+            "test_type must be 't-test', 'u-test', 'scheffe', 'games_howell', or 'dunn'."
         )
     if not isinstance(significant_only, (bool, np.bool_)):
         raise TypeError("significant_only must be a boolean.")

--- a/lmsstat/stat/_allstat.py
+++ b/lmsstat/stat/_allstat.py
@@ -1,11 +1,11 @@
 import pandas as pd
 
-from ._posthoc import dunn_test, scheffe_test
+from ._posthoc import dunn_test, games_howell_test, scheffe_test
 from ._tests import anova_test, kruskal_test, t_test, u_test
 from ._utils import _sanitize_pvalues_df, p_adjust, preprocess_data
 
 
-def allstats(data, p_adj=True):
+def allstats(data, p_adj=True, anova_use_var="equal", posthoc="scheffe"):
     """
     Generates a statistical analysis of the given data.
 
@@ -15,9 +15,23 @@ def allstats(data, p_adj=True):
 
         p_adj (bool, optional): Whether to perform p-value adjustment. Defaults to True.
 
+        anova_use_var ({"equal", "unequal"}, optional): Variance assumption for the
+            ANOVA (3+ groups). "equal" is the classic one-way ANOVA; "unequal" is
+            Welch's ANOVA. Defaults to "equal".
+
+        posthoc ({"scheffe", "games_howell", "both"}, optional): Which parametric
+            post-hoc test(s) to run for 3+ groups. The non-parametric Dunn post-hoc
+            is always included. Defaults to "scheffe". Selection is explicit (no
+            per-feature auto-selection) so result columns stay reproducible.
+
     Returns:
         pandas.DataFrame: The statistical analysis results.
     """
+    if posthoc not in ("scheffe", "games_howell", "both"):
+        raise ValueError("posthoc must be 'scheffe', 'games_howell', or 'both'.")
+    if anova_use_var not in ("equal", "unequal"):
+        raise ValueError("anova_use_var must be 'equal' or 'unequal'.")
+
     _, groups_split, metabolite_names = preprocess_data(data)
 
     num_groups = len(groups_split)
@@ -28,9 +42,17 @@ def allstats(data, p_adj=True):
     result_t = t_test(groups_split, metabolite_names)
     result_u = u_test(groups_split, metabolite_names)
     if num_groups > 2:
-        result_anova = anova_test(groups_split, metabolite_names)
+        result_anova = anova_test(
+            groups_split, metabolite_names, use_var=anova_use_var
+        )
         result_kruskal = kruskal_test(groups_split, metabolite_names)
-        result_scheffe = scheffe_test(groups_split, metabolite_names)
+        parametric_posthoc = []
+        if posthoc in ("scheffe", "both"):
+            parametric_posthoc.append(scheffe_test(groups_split, metabolite_names))
+        if posthoc in ("games_howell", "both"):
+            parametric_posthoc.append(
+                games_howell_test(groups_split, metabolite_names)
+            )
         result_dunn = dunn_test(groups_split, metabolite_names)
 
     if p_adj:
@@ -47,7 +69,7 @@ def allstats(data, p_adj=True):
                 result_t,
                 result_u,
                 result_anova,
-                result_scheffe,
+                *parametric_posthoc,
                 result_kruskal,
                 result_dunn,
             ],

--- a/lmsstat/stat/_tests.py
+++ b/lmsstat/stat/_tests.py
@@ -184,17 +184,22 @@ def u_test(groups_split, metabolite_names) -> pd.DataFrame:
     return df_utest
 
 
-def anova_test(groups_split, metabolite_names) -> pd.DataFrame:
+def anova_test(groups_split, metabolite_names, use_var="equal") -> pd.DataFrame:
     """
     Perform an ANOVA test on groups of data using statsmodels.stats.oneway.anova_oneway.
 
     Args:
         groups_split (pandas.core.groupby.DataFrameGroupBy): A grouped DataFrame object containing the groups to compare.
         metabolite_names (List[str]): A list of metabolite names.
+        use_var ({"equal", "unequal"}): Variance assumption. "equal" runs the
+            classic one-way ANOVA; "unequal" runs Welch's ANOVA. Defaults to "equal".
 
     Returns:
         anova_results (pandas.core.frame.DataFrame): A DataFrame containing the p-value for each metabolite.
     """
+    if use_var not in ("equal", "unequal"):
+        raise ValueError("use_var must be 'equal' or 'unequal'.")
+
     df = groups_split.obj
     groups = df["Group"].values
 
@@ -217,7 +222,7 @@ def anova_test(groups_split, metabolite_names) -> pd.DataFrame:
             continue
 
         try:
-            anova_result = anova_oneway(x_valid, g_valid, use_var="equal")
+            anova_result = anova_oneway(x_valid, g_valid, use_var=use_var)
             p = float(anova_result.pvalue)
         except Exception:
             p = 1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "scipy >= 1.11.0",
   "statsmodels >= 0.14.2",
   "scikit-learn >= 1.0",
-  "pingouin >= 0.5.4",
   "plotnine >= 0.12.0"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,27 @@ def three_group_data():
 
 
 @pytest.fixture()
+def heteroscedastic_data():
+    """Three groups with very different variances and unequal sizes.
+
+    Welch's ANOVA and the classic equal-variance ANOVA diverge meaningfully
+    here (not just by sampling noise), so it is a fair test of use_var.
+    """
+    rng = np.random.default_rng(7)
+    specs = [("X", 12, 0.0, 0.5), ("Y", 8, 0.5, 3.0), ("Z", 20, 1.0, 8.0)]
+    rows = []
+    idx = 0
+    for g, n, mu, sd in specs:
+        for _ in range(n):
+            row = {"Sample": f"H{idx:03d}", "Group": g}
+            for j in range(5):
+                row[f"Met_{j}"] = rng.normal(mu, sd)
+            rows.append(row)
+            idx += 1
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture()
 def preprocessed_two_groups(two_group_data):
     raw, gs, names = preprocess_data(two_group_data)
     return two_group_data, raw, gs, names

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -199,3 +199,13 @@ class TestPlotBar:
         from pathlib import Path
         created = list(Path(outdir).glob("*.png"))
         assert len(created) > 0
+
+    def test_games_howell_test_type(self, three_group_data, tmp_path, monkeypatch):
+        stats = allstats(three_group_data, p_adj=False, posthoc="games_howell")
+        outdir = str(tmp_path / "bar_gh")
+        monkeypatch.setitem(FOLDER, "bar", outdir)
+        result = plot_bar(three_group_data, stats, test_type="games_howell", max_workers=1)
+        assert result is None
+        from pathlib import Path
+        created = list(Path(outdir).glob("*.png"))
+        assert len(created) > 0

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -156,6 +156,21 @@ class TestPlotBox:
         created = list(Path(outdir).glob("*.png"))
         assert len(created) > 0
 
+    def test_games_howell_test_type(self, three_group_data, tmp_path, monkeypatch):
+        stats = allstats(three_group_data, p_adj=False, posthoc="games_howell")
+        outdir = str(tmp_path / "box_gh")
+        monkeypatch.setitem(FOLDER, "box", outdir)
+        result = plot_box(three_group_data, stats, test_type="games_howell", max_workers=1)
+        assert result is None
+        from pathlib import Path
+        created = list(Path(outdir).glob("*.png"))
+        assert len(created) > 0
+
+    def test_invalid_test_type_raises(self, two_group_data):
+        stats = allstats(two_group_data, p_adj=False)
+        with pytest.raises(ValueError):
+            plot_box(two_group_data, stats, test_type="tukey", max_workers=1)
+
     def test_significant_only_filters(self, two_group_data, tmp_path, monkeypatch):
         stats = allstats(two_group_data, p_adj=False)
         outdir_all = str(tmp_path / "box_all")

--- a/tests/test_stat_allstat.py
+++ b/tests/test_stat_allstat.py
@@ -84,6 +84,11 @@ class TestAllstatsPosthocOption:
         with pytest.raises(ValueError):
             allstats(three_group_data, posthoc="tukey")
 
+    def test_invalid_posthoc_raises_for_two_groups(self, two_group_data):
+        # Validated up front, even though two-group data never runs post-hoc.
+        with pytest.raises(ValueError):
+            allstats(two_group_data, posthoc="tukey")
+
     def test_posthoc_noop_for_two_groups(self, two_group_data):
         # No post-hoc columns for two groups regardless of the option.
         result = allstats(two_group_data, posthoc="games_howell")
@@ -106,9 +111,11 @@ class TestAllstatsAnovaUseVar:
         assert result.min().min() >= 0.0
         assert result.max().max() <= 1.0
 
-    def test_equal_vs_unequal_differ(self, three_group_data):
-        eq = allstats(three_group_data, anova_use_var="equal", p_adj=False)
-        un = allstats(three_group_data, anova_use_var="unequal", p_adj=False)
+    def test_equal_vs_unequal_differ(self, heteroscedastic_data):
+        # Unequal variances + unequal group sizes make Welch and classic ANOVA
+        # diverge for a principled reason, not just sampling noise.
+        eq = allstats(heteroscedastic_data, anova_use_var="equal", p_adj=False)
+        un = allstats(heteroscedastic_data, anova_use_var="unequal", p_adj=False)
         assert not np.allclose(eq["p-value_ANOVA"].values, un["p-value_ANOVA"].values)
 
     def test_invalid_use_var_raises(self, three_group_data):

--- a/tests/test_stat_allstat.py
+++ b/tests/test_stat_allstat.py
@@ -55,3 +55,67 @@ class TestAllstats:
         assert any("_scheffe" in c for c in cols)
         assert any("KW" in c for c in cols)
         assert any("_dunn" in c for c in cols)
+
+
+class TestAllstatsPosthocOption:
+    def test_default_posthoc_is_scheffe_only(self, three_group_data):
+        result = allstats(three_group_data)
+        cols = result.columns.tolist()
+        assert any("_scheffe" in c for c in cols)
+        assert not any("_games_howell" in c for c in cols)
+
+    def test_posthoc_games_howell(self, three_group_data):
+        result = allstats(three_group_data, posthoc="games_howell")
+        cols = result.columns.tolist()
+        assert any("_games_howell" in c for c in cols)
+        assert not any("_scheffe" in c for c in cols)
+        # same total column count as the scheffe default (swap, not add)
+        assert result.shape == (5, 14)
+
+    def test_posthoc_both(self, three_group_data):
+        result = allstats(three_group_data, posthoc="both")
+        cols = result.columns.tolist()
+        assert any("_scheffe" in c for c in cols)
+        assert any("_games_howell" in c for c in cols)
+        # 3 ttest + 3 utest + 1 ANOVA + 3 scheffe + 3 games_howell + 1 KW + 3 dunn = 17
+        assert result.shape == (5, 17)
+
+    def test_invalid_posthoc_raises(self, three_group_data):
+        with pytest.raises(ValueError):
+            allstats(three_group_data, posthoc="tukey")
+
+    def test_posthoc_noop_for_two_groups(self, two_group_data):
+        # No post-hoc columns for two groups regardless of the option.
+        result = allstats(two_group_data, posthoc="games_howell")
+        assert result.shape == (5, 2)
+
+    def test_values_in_01_with_both(self, three_group_data):
+        result = allstats(three_group_data, posthoc="both")
+        assert result.min().min() >= 0.0
+        assert result.max().max() <= 1.0
+
+
+class TestAllstatsAnovaUseVar:
+    def test_default_runs_equal_var(self, three_group_data):
+        result = allstats(three_group_data)
+        assert any("ANOVA" in c for c in result.columns)
+
+    def test_unequal_var_runs(self, three_group_data):
+        result = allstats(three_group_data, anova_use_var="unequal")
+        assert any("ANOVA" in c for c in result.columns)
+        assert result.min().min() >= 0.0
+        assert result.max().max() <= 1.0
+
+    def test_equal_vs_unequal_differ(self, three_group_data):
+        eq = allstats(three_group_data, anova_use_var="equal", p_adj=False)
+        un = allstats(three_group_data, anova_use_var="unequal", p_adj=False)
+        assert not np.allclose(eq["p-value_ANOVA"].values, un["p-value_ANOVA"].values)
+
+    def test_invalid_use_var_raises(self, three_group_data):
+        with pytest.raises(ValueError):
+            allstats(three_group_data, anova_use_var="bogus")
+
+    def test_invalid_use_var_raises_for_two_groups(self, two_group_data):
+        # Validated up front, even though two-group data never runs ANOVA.
+        with pytest.raises(ValueError):
+            allstats(two_group_data, anova_use_var="bogus")

--- a/tests/test_stat_tests.py
+++ b/tests/test_stat_tests.py
@@ -161,8 +161,8 @@ class TestAnovaTest:
         assert result.min().min() >= 0.0
         assert result.max().max() <= 1.0
 
-    def test_equal_vs_unequal_differ(self, preprocessed_three_groups):
-        _, _, gs, names = preprocessed_three_groups
+    def test_equal_vs_unequal_differ(self, heteroscedastic_data):
+        _, gs, names = preprocess_data(heteroscedastic_data)
         eq = anova_test(gs, names, use_var="equal")
         un = anova_test(gs, names, use_var="unequal")
         assert not np.allclose(eq.values, un.values)

--- a/tests/test_stat_tests.py
+++ b/tests/test_stat_tests.py
@@ -154,6 +154,24 @@ class TestAnovaTest:
         idx = names.index("Met_4")
         assert result.iloc[idx, 0] == 1.0
 
+    def test_unequal_var_runs(self, preprocessed_three_groups):
+        _, _, gs, names = preprocessed_three_groups
+        result = anova_test(gs, names, use_var="unequal")
+        assert result.shape == (5, 1)
+        assert result.min().min() >= 0.0
+        assert result.max().max() <= 1.0
+
+    def test_equal_vs_unequal_differ(self, preprocessed_three_groups):
+        _, _, gs, names = preprocessed_three_groups
+        eq = anova_test(gs, names, use_var="equal")
+        un = anova_test(gs, names, use_var="unequal")
+        assert not np.allclose(eq.values, un.values)
+
+    def test_invalid_use_var_raises(self, preprocessed_three_groups):
+        _, _, gs, names = preprocessed_three_groups
+        with pytest.raises(ValueError):
+            anova_test(gs, names, use_var="bogus")
+
 
 # ── kruskal_test ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

P0 fixes to make the `allstats()` post-hoc/ANOVA API explicit and reproducible, plus removal of a dead dependency. **Default behavior is unchanged** — existing `allstats(data)` output keeps the same shape and columns.

### Changes
- `allstats(data, p_adj=True, anova_use_var="equal", posthoc="scheffe")`
  - `posthoc="scheffe" | "games_howell" | "both"` (the previously-orphaned `games_howell_test` is now wired in). Dunn is always included.
  - `anova_use_var="equal" | "unequal"` (Welch's ANOVA).
  - Both options validated **up front**, so invalid values raise even for two-group input that never reaches the ANOVA/post-hoc path.
  - No per-feature auto-selection, so result columns stay reproducible.
- `anova_test(..., use_var="equal")` threads the variance assumption to `anova_oneway`.
- `plot_box` / `plot_bar` accept `test_type="games_howell"`.
- Removed unused `pingouin` dependency (Welch is covered by `statsmodels.stats.oneway.anova_oneway`).
- README updated for the new options.

### Tests
16 new tests; full suite **166 passing** locally (conda env `lmsstat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

구성 가능한 ANOVA 분산 가정과 모수 사후 검정 선택 옵션을 allstats에 추가하고, Games-Howell 검정을 통계 및 플로팅 API 전반에서 사용할 수 있도록 노출했으며, 사용되지 않는 통계 의존성을 제거하고 새 옵션에 대한 문서화와 테스트를 추가합니다.

New Features:
- `allstats()`에 `anova_use_var` 옵션을 추가하여 3개 이상의 그룹에 대해 고전적 일원 ANOVA와 Welch의 ANOVA 중에서 선택할 수 있도록 확장.
- `allstats()`에 `posthoc` 옵션을 추가하여 Dunn 검정과 함께 Scheffé, Games-Howell 또는 두 모수 사후 검정을 모두 선택할 수 있도록 확장.
- `plot_box` 및 `plot_bar`에서 `test_type="games_howell"`을 통해 Games-Howell p-value를 사용할 수 있도록 허용.

Bug Fixes:
- 두 그룹 입력에 대해서도 잘못된 구성이 빠르게 실패하도록, ANOVA 분산 및 사후 검정 선택 옵션을 사전에 검증.
- 유효한 p-value 범위를 유지하기 위해 ANOVA 및 사후 검정 결과가 0과 1 사이에 머물도록 보장.

Enhancements:
- 기존 `games_howell_test`를 allstats 파이프라인에 연결하여 그 결과가 집계된 통계 출력에 포함되도록 함.
- 분산 가정 파라미터를 `anova_test`를 통해 statsmodels의 `anova_oneway`까지 전달하여 일관된 동작을 보장.
- ANOVA 분산 가정, 사후 검정, 플로팅의 `test_type` 선택을 구성하는 README 사용 예시를 명확히 함.

Build:
- 프로젝트 의존성에서 사용되지 않는 `pingouin` 의존성을 제거.

Tests:
- 새로운 `allstats`의 `posthoc` 및 `anova_use_var` 옵션에 대해, 잘못된 값과 두 그룹 동작을 포함한 커버리지 추가.
- `anova_test`의 분산 가정 처리 및 플로팅 유틸리티에서 Games-Howell 지원과 검증에 대한 테스트 추가.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable ANOVA variance assumptions and parametric post-hoc selection to allstats, expose Games-Howell across stats and plotting APIs, and drop an unused stats dependency while documenting and testing the new options.

New Features:
- Extend allstats() to accept an anova_use_var option to choose between classic one-way ANOVA and Welch's ANOVA for 3+ groups.
- Extend allstats() to accept a posthoc option to select Scheffé, Games-Howell, or both parametric post-hoc tests alongside Dunn.
- Allow plot_box and plot_bar to use Games-Howell p-values via test_type="games_howell".

Bug Fixes:
- Validate ANOVA variance and post-hoc selection options up front so invalid configurations fail fast even for two-group inputs.
- Ensure ANOVA and post-hoc outputs remain bounded between 0 and 1, preserving valid p-value ranges.

Enhancements:
- Wire the existing games_howell_test into the allstats pipeline so its results are available in the aggregated stats output.
- Thread the variance assumption parameter through anova_test to statsmodels' anova_oneway for consistent behavior.
- Clarify README usage examples for configuring ANOVA variance assumptions, post-hoc tests, and plotting test_type selections.

Build:
- Remove the unused pingouin dependency from the project dependencies.

Tests:
- Add coverage for the new allstats posthoc and anova_use_var options, including invalid values and two-group behavior.
- Add tests for anova_test variance assumption handling and for Games-Howell support and validation in plotting utilities.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `allstats()` now supports Welch's ANOVA and configurable parametric post-hoc tests (Scheffé, Games-Howell).
  * Plotting supports Games-Howell test type for significance bracket determination.

* **Documentation**
  * Updated README with examples showing how to customize ANOVA assumptions and post-hoc test options.

* **Tests**
  * Added comprehensive test coverage for new ANOVA and post-hoc test options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->