### PR TITLE
Preprocessing module: imputation, log transform, sample normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ scaled_data.to_csv("scaled_data.csv")
 scaled_data
 ```
 
+### Preprocessing (imputation, log transform, normalization)
+
+All preprocessing functions return a new DataFrame (the input is never mutated)
+and keep the `Sample`/`Group` columns and the original feature order.
+
+```python
+import pandas as pd
+from lmsstat import stat
+
+data = pd.read_csv("data.csv")
+
+# Missing-value imputation: "half_min" (LC-MS below-LOD), "min", or "knn"
+data = stat.impute_missing(data, method="half_min")
+
+# Sample-wise normalization: "median", "total_area", or "pqn"
+data = stat.normalize(data, method="pqn")
+
+# Log transform: log_base(x + offset); base may be 2, 10, np.e, ...
+data = stat.log_transform(data, base=2, offset=1.0)
+```
+
+A typical order is impute → normalize → log transform → `scaling`, after which
+`allstats`, volcano/PLS-DA, and the heatmap operate on cleaner inputs.
+
 ### PCA
 
 ```python

--- a/lmsstat/stat/__init__.py
+++ b/lmsstat/stat/__init__.py
@@ -1,4 +1,5 @@
 from ._allstat import allstats
 from ._posthoc import dunn_test, scheffe_test, games_howell_test
+from ._preprocess import impute_missing, log_transform, normalize
 from ._utils import preprocess_data, p_adjust, correlation, scaling
 from ._tests import t_test, u_test, anova_test, kruskal_test, norm_test

--- a/lmsstat/stat/_preprocess.py
+++ b/lmsstat/stat/_preprocess.py
@@ -1,0 +1,171 @@
+"""
+Preprocessing utilities for metabolomics tables.
+
+Every function in this module follows the same contract:
+    * the input DataFrame is never mutated;
+    * a new DataFrame is returned with the first two columns standardized to
+      ``Sample`` and ``Group`` (unchanged values) followed by the feature
+      columns in their original order;
+    * feature columns are coerced to numeric (non-numeric → NaN).
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from ._utils import ensure_sample_group_columns
+
+
+def _split(data: pd.DataFrame):
+    """Return (Sample/Group frame, numeric feature frame) without mutating input."""
+    data = ensure_sample_group_columns(data)
+    numeric = (
+        data.drop(columns=["Sample", "Group"])
+        .apply(pd.to_numeric, errors="coerce")
+    )
+    return data, numeric
+
+
+def _reassemble(data: pd.DataFrame, numeric: pd.DataFrame) -> pd.DataFrame:
+    """Glue Sample/Group back onto a transformed numeric block, preserving order."""
+    return pd.concat(
+        [
+            data[["Sample", "Group"]].reset_index(drop=True),
+            numeric.reset_index(drop=True),
+        ],
+        axis=1,
+    )
+
+
+def impute_missing(data: pd.DataFrame, method: str = "half_min") -> pd.DataFrame:
+    """
+    Impute missing feature values.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Wide table. Col0 = Sample, Col1 = Group, remaining = features.
+    method : {"half_min", "min", "knn"}
+        * ``"min"``      – replace NaN in each feature with that feature's
+          minimum observed value.
+        * ``"half_min"`` – replace NaN with half the feature's minimum observed
+          value (a common below-limit-of-detection imputation for LC-MS data).
+        * ``"knn"``      – k-nearest-neighbours imputation across samples.
+
+    Notes
+    -----
+    A feature with no observed values cannot be imputed and is left as NaN.
+    """
+    if method not in ("half_min", "min", "knn"):
+        raise ValueError("method must be 'half_min', 'min', or 'knn'.")
+
+    data, numeric = _split(data)
+
+    if method in ("min", "half_min"):
+        mins = numeric.min(axis=0, skipna=True)
+        fill = mins if method == "min" else mins / 2.0
+        numeric = numeric.fillna(fill)
+    else:  # knn
+        from sklearn.impute import KNNImputer
+
+        n_samples = numeric.shape[0]
+        n_neighbors = max(1, min(5, n_samples - 1))
+        X = numeric.to_numpy(dtype=float)
+        imputed = KNNImputer(n_neighbors=n_neighbors).fit_transform(X)
+        numeric = pd.DataFrame(
+            imputed, columns=numeric.columns, index=numeric.index
+        )
+
+    return _reassemble(data, numeric)
+
+
+def log_transform(data: pd.DataFrame, base: float = 2, offset: float = 1.0) -> pd.DataFrame:
+    """
+    Apply a logarithmic transform ``log_base(x + offset)`` to feature columns.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Wide table. Col0 = Sample, Col1 = Group, remaining = features.
+    base : float
+        Logarithm base (must be > 0 and != 1). Common values: 2, 10, ``np.e``.
+    offset : float
+        Added before the log to keep zeros finite. Defaults to 1.0.
+
+    Raises
+    ------
+    ValueError
+        If ``base`` is invalid, or any observed value would be non-positive
+        after adding ``offset`` (suggest a larger offset). NaNs are preserved.
+    """
+    if not np.isfinite(base) or base <= 0 or base == 1:
+        raise ValueError("base must be a positive number other than 1.")
+
+    data, numeric = _split(data)
+
+    shifted = numeric.to_numpy(dtype=float) + offset
+    finite = np.isfinite(shifted)
+    if np.any(finite & (shifted <= 0)):
+        raise ValueError(
+            "Some values are <= 0 after adding offset; increase offset before "
+            "log-transforming."
+        )
+
+    logged = np.log(shifted) / np.log(base)
+    numeric = pd.DataFrame(logged, columns=numeric.columns, index=numeric.index)
+    return _reassemble(data, numeric)
+
+
+def _safe_denominator(denom: np.ndarray) -> np.ndarray:
+    """Replace non-finite or zero denominators with 1.0 (leaves the row unscaled)."""
+    return np.where(~np.isfinite(denom) | (denom == 0), 1.0, denom)
+
+
+def normalize(data: pd.DataFrame, method: str = "median") -> pd.DataFrame:
+    """
+    Sample-wise (row) normalization to correct for dilution / loading differences.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Wide table. Col0 = Sample, Col1 = Group, remaining = features.
+    method : {"median", "total_area", "pqn"}
+        * ``"median"``     – divide each sample by its median feature value.
+        * ``"total_area"`` – divide each sample by the sum of its features
+          (constant-sum / integral normalization).
+        * ``"pqn"``        – Probabilistic Quotient Normalization (Dieterle 2006):
+          integral-normalize, build a median reference spectrum, then divide each
+          sample by the median quotient against the reference.
+
+    Notes
+    -----
+    NaNs are ignored when computing per-sample factors and preserved in the
+    output. Degenerate factors (zero / non-finite) leave the sample unscaled.
+    """
+    if method not in ("median", "total_area", "pqn"):
+        raise ValueError("method must be 'median', 'total_area', or 'pqn'.")
+
+    data, numeric = _split(data)
+    X = numeric.to_numpy(dtype=float)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        if method == "total_area":
+            denom = _safe_denominator(np.nansum(X, axis=1, keepdims=True))
+            Xn = X / denom
+        elif method == "median":
+            denom = _safe_denominator(np.nanmedian(X, axis=1, keepdims=True))
+            Xn = X / denom
+        else:  # pqn
+            row_sum = _safe_denominator(np.nansum(X, axis=1, keepdims=True))
+            X1 = X / row_sum
+            ref = np.nanmedian(X1, axis=0)
+            ref_valid = np.isfinite(ref) & (ref > 0)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                quot = np.where(ref_valid[None, :], X1 / ref, np.nan)
+            dil = _safe_denominator(np.nanmedian(quot, axis=1, keepdims=True))
+            Xn = X1 / dil
+
+    numeric = pd.DataFrame(Xn, columns=numeric.columns, index=numeric.index)
+    return _reassemble(data, numeric)

--- a/lmsstat/stat/_preprocess.py
+++ b/lmsstat/stat/_preprocess.py
@@ -28,14 +28,12 @@ def _split(data: pd.DataFrame):
 
 
 def _reassemble(data: pd.DataFrame, numeric: pd.DataFrame) -> pd.DataFrame:
-    """Glue Sample/Group back onto a transformed numeric block, preserving order."""
-    return pd.concat(
-        [
-            data[["Sample", "Group"]].reset_index(drop=True),
-            numeric.reset_index(drop=True),
-        ],
-        axis=1,
-    )
+    """Glue Sample/Group back onto a transformed numeric block.
+
+    Preserves both the original column order and the input row index. ``data``
+    and ``numeric`` share the index produced by ``_split``, so they align.
+    """
+    return pd.concat([data[["Sample", "Group"]], numeric], axis=1)
 
 
 def impute_missing(data: pd.DataFrame, method: str = "half_min") -> pd.DataFrame:

--- a/lmsstat/stat/_preprocess.py
+++ b/lmsstat/stat/_preprocess.py
@@ -51,6 +51,8 @@ def impute_missing(data: pd.DataFrame, method: str = "half_min") -> pd.DataFrame
           minimum observed value.
         * ``"half_min"`` – replace NaN with half the feature's minimum observed
           value (a common below-limit-of-detection imputation for LC-MS data).
+          Intended for raw, non-negative intensity data; with negative values
+          half of a negative minimum is more negative, which is rarely meaningful.
         * ``"knn"``      – k-nearest-neighbours imputation across samples.
 
     Notes
@@ -69,13 +71,17 @@ def impute_missing(data: pd.DataFrame, method: str = "half_min") -> pd.DataFrame
     else:  # knn
         from sklearn.impute import KNNImputer
 
-        n_samples = numeric.shape[0]
-        n_neighbors = max(1, min(5, n_samples - 1))
-        X = numeric.to_numpy(dtype=float)
-        imputed = KNNImputer(n_neighbors=n_neighbors).fit_transform(X)
-        numeric = pd.DataFrame(
-            imputed, columns=numeric.columns, index=numeric.index
-        )
+        # KNNImputer drops all-missing columns, so impute only the columns with
+        # at least one observed value and leave all-NaN features as NaN.
+        observed = numeric.columns[numeric.notna().any(axis=0)]
+        if len(observed) > 0:
+            n_samples = numeric.shape[0]
+            n_neighbors = max(1, min(5, n_samples - 1))
+            imputed = KNNImputer(n_neighbors=n_neighbors).fit_transform(
+                numeric[observed].to_numpy(dtype=float)
+            )
+            numeric = numeric.copy()
+            numeric[observed] = imputed
 
     return _reassemble(data, numeric)
 
@@ -101,6 +107,8 @@ def log_transform(data: pd.DataFrame, base: float = 2, offset: float = 1.0) -> p
     """
     if not np.isfinite(base) or base <= 0 or base == 1:
         raise ValueError("base must be a positive number other than 1.")
+    if not np.isfinite(offset):
+        raise ValueError("offset must be a finite number.")
 
     data, numeric = _split(data)
 

--- a/tests/test_stat_preprocess.py
+++ b/tests/test_stat_preprocess.py
@@ -96,6 +96,23 @@ class TestContract:
         assert out["Group"].tolist() == ["A", "B"]
         assert out["Met_0"].isna().all()
 
+    @pytest.mark.parametrize(
+        "fn",
+        [
+            lambda d: impute_missing(d, method="min"),
+            lambda d: log_transform(d),
+            lambda d: normalize(d, method="median"),
+        ],
+    )
+    def test_preserves_input_index(self, fn):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "Met_0": [1.0, 2.0, 3.0], "Met_1": [4.0, 5.0, 6.0]},
+            index=["r1", "r2", "r3"],
+        )
+        out = fn(df)
+        assert list(out.index) == ["r1", "r2", "r3"]
+
 
 # ── impute_missing ─────────────────────────────────────────────────────────
 

--- a/tests/test_stat_preprocess.py
+++ b/tests/test_stat_preprocess.py
@@ -1,0 +1,223 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from lmsstat.stat._preprocess import impute_missing, log_transform, normalize
+
+
+@pytest.fixture()
+def simple_data():
+    """Small, fully-known wide table for exact-value assertions."""
+    return pd.DataFrame(
+        {
+            "Sample": ["S0", "S1", "S2", "S3"],
+            "Group": ["A", "A", "B", "B"],
+            "Met_0": [1.0, 2.0, 3.0, 4.0],
+            "Met_1": [10.0, 20.0, 30.0, 40.0],
+            "Met_2": [100.0, 200.0, 300.0, 400.0],
+        }
+    )
+
+
+@pytest.fixture()
+def positive_with_nan():
+    """Strictly positive feature values with a couple of NaNs (valid for all three)."""
+    return pd.DataFrame(
+        {
+            "Sample": ["S0", "S1", "S2", "S3"],
+            "Group": ["A", "A", "B", "B"],
+            "Met_0": [1.0, np.nan, 3.0, 4.0],
+            "Met_1": [10.0, 20.0, np.nan, 40.0],
+            "Met_2": [100.0, 200.0, 300.0, 400.0],
+        }
+    )
+
+
+@pytest.fixture()
+def single_group_data():
+    return pd.DataFrame(
+        {
+            "Sample": ["S0", "S1", "S2"],
+            "Group": ["A", "A", "A"],
+            "Met_0": [1.0, np.nan, 3.0],
+            "Met_1": [4.0, 5.0, 6.0],
+        }
+    )
+
+
+# ── shared contract ──────────────────────────────────────────────────────
+
+class TestContract:
+    @pytest.mark.parametrize(
+        "fn",
+        [
+            lambda d: impute_missing(d, method="min"),
+            lambda d: log_transform(d),
+            lambda d: normalize(d, method="median"),
+        ],
+    )
+    def test_preserves_sample_group_and_order(self, simple_data, fn):
+        out = fn(simple_data)
+        assert list(out.columns) == list(simple_data.columns)
+        assert out["Sample"].tolist() == simple_data["Sample"].tolist()
+        assert out["Group"].tolist() == simple_data["Group"].tolist()
+
+    @pytest.mark.parametrize(
+        "fn",
+        [
+            lambda d: impute_missing(d, method="min"),
+            lambda d: log_transform(d),
+            lambda d: normalize(d, method="median"),
+        ],
+    )
+    def test_does_not_mutate_input(self, positive_with_nan, fn):
+        before = positive_with_nan.copy(deep=True)
+        _ = fn(positive_with_nan)
+        pd.testing.assert_frame_equal(positive_with_nan, before)
+
+
+# ── impute_missing ─────────────────────────────────────────────────────────
+
+class TestImputeMissing:
+    def test_min_fills_all_nans(self, data_with_nans):
+        out = impute_missing(data_with_nans, method="min")
+        assert out.iloc[:, 2:].isna().sum().sum() == 0
+
+    def test_half_min_fills_all_nans(self, data_with_nans):
+        out = impute_missing(data_with_nans, method="half_min")
+        assert out.iloc[:, 2:].isna().sum().sum() == 0
+
+    def test_knn_fills_all_nans(self, data_with_nans):
+        out = impute_missing(data_with_nans, method="knn")
+        assert out.iloc[:, 2:].isna().sum().sum() == 0
+
+    def test_min_uses_column_minimum(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "Met_0": [2.0, 5.0, np.nan]}
+        )
+        out = impute_missing(df, method="min")
+        assert out.loc[2, "Met_0"] == 2.0
+
+    def test_half_min_uses_half_column_minimum(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "Met_0": [2.0, 5.0, np.nan]}
+        )
+        out = impute_missing(df, method="half_min")
+        assert out.loc[2, "Met_0"] == 1.0
+
+    def test_does_not_change_observed_values(self, simple_data):
+        out = impute_missing(simple_data, method="half_min")
+        pd.testing.assert_frame_equal(
+            out[simple_data.columns], simple_data, check_dtype=False
+        )
+
+    def test_all_nan_column_stays_nan(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"],
+             "Met_0": [np.nan, np.nan], "Met_1": [1.0, 2.0]}
+        )
+        out = impute_missing(df, method="half_min")
+        assert out["Met_0"].isna().all()
+
+    def test_single_group(self, single_group_data):
+        out = impute_missing(single_group_data, method="min")
+        assert out["Met_0"].isna().sum() == 0
+
+    def test_invalid_method_raises(self, simple_data):
+        with pytest.raises(ValueError):
+            impute_missing(simple_data, method="bogus")
+
+
+# ── log_transform ──────────────────────────────────────────────────────────
+
+class TestLogTransform:
+    def test_log2_known_values(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"], "Met_0": [3.0, 7.0]}
+        )
+        out = log_transform(df, base=2, offset=1.0)
+        # log2(3+1)=2, log2(7+1)=3
+        assert out.loc[0, "Met_0"] == pytest.approx(2.0)
+        assert out.loc[1, "Met_0"] == pytest.approx(3.0)
+
+    def test_offset_handles_zero(self):
+        df = pd.DataFrame(
+            {"Sample": ["a"], "Group": ["A"], "Met_0": [0.0]}
+        )
+        out = log_transform(df, base=2, offset=1.0)
+        assert out.loc[0, "Met_0"] == pytest.approx(0.0)
+
+    def test_base10(self):
+        df = pd.DataFrame(
+            {"Sample": ["a"], "Group": ["A"], "Met_0": [99.0]}
+        )
+        out = log_transform(df, base=10, offset=1.0)
+        assert out.loc[0, "Met_0"] == pytest.approx(2.0)
+
+    def test_base_e(self):
+        df = pd.DataFrame(
+            {"Sample": ["a"], "Group": ["A"], "Met_0": [np.e - 1.0]}
+        )
+        out = log_transform(df, base=np.e, offset=1.0)
+        assert out.loc[0, "Met_0"] == pytest.approx(1.0)
+
+    def test_preserves_nan(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"], "Met_0": [np.nan, 3.0]}
+        )
+        out = log_transform(df, base=2, offset=1.0)
+        assert np.isnan(out.loc[0, "Met_0"])
+
+    def test_nonpositive_after_offset_raises(self):
+        df = pd.DataFrame(
+            {"Sample": ["a"], "Group": ["A"], "Met_0": [-5.0]}
+        )
+        with pytest.raises(ValueError):
+            log_transform(df, base=2, offset=1.0)
+
+    def test_invalid_base_raises(self, simple_data):
+        with pytest.raises(ValueError):
+            log_transform(simple_data, base=1)
+
+
+# ── normalize ──────────────────────────────────────────────────────────────
+
+class TestNormalize:
+    def test_total_area_rows_sum_to_one(self, simple_data):
+        out = normalize(simple_data, method="total_area")
+        row_sums = out.iloc[:, 2:].sum(axis=1)
+        assert np.allclose(row_sums.to_numpy(), 1.0)
+
+    def test_median_rows_have_unit_median(self, simple_data):
+        out = normalize(simple_data, method="median")
+        row_meds = out.iloc[:, 2:].median(axis=1)
+        assert np.allclose(row_meds.to_numpy(), 1.0)
+
+    def test_pqn_runs_and_keeps_shape(self, simple_data):
+        out = normalize(simple_data, method="pqn")
+        assert out.shape == simple_data.shape
+        assert np.isfinite(out.iloc[:, 2:].to_numpy(dtype=float)).all()
+
+    def test_total_area_zero_sum_row_does_not_crash(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"],
+             "Met_0": [0.0, 2.0], "Met_1": [0.0, 4.0]}
+        )
+        out = normalize(df, method="total_area")
+        # zero-sum row left unchanged (no inf/nan introduced)
+        assert np.isfinite(out.iloc[:, 2:].to_numpy(dtype=float)).all()
+
+    def test_handles_nan(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"],
+             "Met_0": [1.0, np.nan], "Met_1": [3.0, 4.0]}
+        )
+        out = normalize(df, method="median")
+        # NaN stays NaN; observed entries finite
+        assert np.isnan(out.loc[1, "Met_0"])
+
+    def test_invalid_method_raises(self, simple_data):
+        with pytest.raises(ValueError):
+            normalize(simple_data, method="bogus")

--- a/tests/test_stat_preprocess.py
+++ b/tests/test_stat_preprocess.py
@@ -121,6 +121,19 @@ class TestImputeMissing:
         out = impute_missing(df, method="half_min")
         assert out["Met_0"].isna().all()
 
+    def test_knn_all_nan_column_stays_nan(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "Met_0": [np.nan, np.nan, np.nan],
+             "Met_1": [1.0, np.nan, 3.0],
+             "Met_2": [4.0, 5.0, 6.0]}
+        )
+        out = impute_missing(df, method="knn")
+        # Column order preserved, all-NaN feature stays NaN, others imputed.
+        assert list(out.columns) == list(df.columns)
+        assert out["Met_0"].isna().all()
+        assert out["Met_1"].isna().sum() == 0
+
     def test_single_group(self, single_group_data):
         out = impute_missing(single_group_data, method="min")
         assert out["Met_0"].isna().sum() == 0
@@ -180,6 +193,11 @@ class TestLogTransform:
     def test_invalid_base_raises(self, simple_data):
         with pytest.raises(ValueError):
             log_transform(simple_data, base=1)
+
+    @pytest.mark.parametrize("bad_offset", [np.nan, np.inf, -np.inf])
+    def test_non_finite_offset_raises(self, simple_data, bad_offset):
+        with pytest.raises(ValueError):
+            log_transform(simple_data, offset=bad_offset)
 
 
 # ── normalize ──────────────────────────────────────────────────────────────

--- a/tests/test_stat_preprocess.py
+++ b/tests/test_stat_preprocess.py
@@ -75,6 +75,27 @@ class TestContract:
         _ = fn(positive_with_nan)
         pd.testing.assert_frame_equal(positive_with_nan, before)
 
+    @pytest.mark.parametrize(
+        "fn",
+        [
+            lambda d: impute_missing(d, method="min"),
+            lambda d: log_transform(d),
+            lambda d: normalize(d, method="median"),
+        ],
+    )
+    def test_non_numeric_feature_coerced_to_nan(self, fn):
+        # A fully non-numeric feature column becomes all-NaN (per _split contract);
+        # none of the three functions can manufacture a value for it.
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"],
+             "Met_0": ["x", "y"], "Met_1": [1.0, 2.0]}
+        )
+        out = fn(df)
+        assert list(out.columns) == list(df.columns)
+        assert out["Sample"].tolist() == ["a", "b"]
+        assert out["Group"].tolist() == ["A", "B"]
+        assert out["Met_0"].isna().all()
+
 
 # ── impute_missing ─────────────────────────────────────────────────────────
 
@@ -137,6 +158,26 @@ class TestImputeMissing:
     def test_single_group(self, single_group_data):
         out = impute_missing(single_group_data, method="min")
         assert out["Met_0"].isna().sum() == 0
+
+    def test_knn_single_sample_does_not_error(self):
+        # n_neighbors = max(1, min(5, 0)) = 1; must not crash on one sample.
+        df = pd.DataFrame(
+            {"Sample": ["a"], "Group": ["A"], "Met_0": [5.0], "Met_1": [7.0]}
+        )
+        out = impute_missing(df, method="knn")
+        assert out.shape == df.shape
+        assert np.isfinite(out.iloc[:, 2:].to_numpy(dtype=float)).all()
+
+    def test_knn_all_nan_row(self):
+        # A fully-missing sample is filled from observed columns (sklearn falls
+        # back to column means) — codify "no crash, shape preserved, finite".
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "Met_0": [np.nan, 2.0, 3.0], "Met_1": [np.nan, 5.0, 6.0]}
+        )
+        out = impute_missing(df, method="knn")
+        assert out.shape == df.shape
+        assert np.isfinite(out.iloc[:, 2:].to_numpy(dtype=float)).all()
 
     def test_invalid_method_raises(self, simple_data):
         with pytest.raises(ValueError):
@@ -235,6 +276,26 @@ class TestNormalize:
         out = normalize(df, method="median")
         # NaN stays NaN; observed entries finite
         assert np.isnan(out.loc[1, "Met_0"])
+
+    @pytest.mark.parametrize("method", ["median", "total_area", "pqn"])
+    def test_all_nan_row_preserved(self, method):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"],
+             "Met_0": [np.nan, 2.0], "Met_1": [np.nan, 4.0]}
+        )
+        out = normalize(df, method=method)
+        assert out.loc[0, ["Met_0", "Met_1"]].isna().all()
+        assert not np.isinf(out.iloc[:, 2:].to_numpy(dtype=float)).any()
+
+    @pytest.mark.parametrize("method", ["median", "total_area", "pqn"])
+    def test_all_nan_feature_column_preserved(self, method):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b"], "Group": ["A", "B"],
+             "Met_0": [np.nan, np.nan], "Met_1": [1.0, 2.0]}
+        )
+        out = normalize(df, method=method)
+        assert out["Met_0"].isna().all()
+        assert not np.isinf(out.iloc[:, 2:].to_numpy(dtype=float)).any()
 
     def test_invalid_method_raises(self, simple_data):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

New `lmsstat.stat` preprocessing module for metabolomics inputs. Independent of #1 (both branch off `develop`).

### Functions (exported via `lmsstat.stat`)
- `impute_missing(method="half_min" | "min" | "knn")` — `half_min` targets raw non-negative LC-MS intensities (below-LOD).
- `log_transform(base=2, offset=1.0)` — `log_base(x + offset)`.
- `normalize(method="median" | "total_area" | "pqn")` — sample-wise dilution correction; PQN = integral normalization then median-quotient correction (Dieterle 2006).

### Contract (enforced by tests)
- Input DataFrame is **never mutated**.
- Output keeps `Sample`/`Group` columns and the **original feature order**.
- Feature columns coerced to numeric.
- Degenerate per-sample factors (zero / non-finite) leave the row unscaled; all-missing features are left as NaN (incl. the `knn` path).
- `log_transform` raises on invalid `base`, non-finite `offset`, and non-positive-after-offset values; NaNs preserved.

### Edge cases covered
NaN, all-NaN feature (incl. KNN), single group, zero-sum row, zero/negative log inputs.

### Tests
32 new tests; full suite **182 passing** locally (conda env `lmsstat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

대사체 데이터에 대한 전처리 모듈을 추가하여, 누락값 대체(imputation), 로그 변환, 샘플 단위 정규화 유틸리티를 제공하며, 이를 문서화하고 테스트로 검증했습니다.

New Features:
- `Sample/Group` 메타데이터와 피처 순서를 유지하면서, 컬럼 단위 최소값, 최소값의 절반, 또는 KNN 기반 누락값 대체를 수행하는 `impute_missing`를 도입했습니다.
- 오프셋이 적용된 로그 변환을 수행하고, 기반(base)을 설정 가능하게 하며 입력값을 견고하게 검증하는 `log_transform`를 추가했습니다.
- 대사체 테이블에서 희석 보정을 위해 샘플 단위 중앙값(median), 전체 면적(total area), 또는 PQN 정규화를 수행하는 `normalize`를 추가했습니다.

Documentation:
- README에 누락값 대체, 정규화, 로그 변환 예시를 포함한 전처리 워크플로를 문서화했습니다.

Tests:
- 전처리 공통 계약(shared preprocessing contract)과 누락값 대체, 로그 변환, 정규화 메서드에 대한 에지 케이스를 검증하는 전용 테스트 스위트를 추가했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a preprocessing module for metabolomics data providing imputation, log transformation, and sample-wise normalization utilities, documented and covered by tests.

New Features:
- Introduce impute_missing for column-wise minimum, half-minimum, or KNN-based missing value imputation that preserves Sample/Group metadata and feature ordering.
- Add log_transform to apply offsetted logarithmic transforms with configurable base and robust validation of inputs.
- Add normalize to perform sample-wise median, total area, or PQN normalization for dilution correction in metabolomics tables.

Documentation:
- Document preprocessing workflow with examples for imputation, normalization, and log transformation in the README.

Tests:
- Add a dedicated test suite validating the shared preprocessing contract and edge cases for imputation, log transformation, and normalization methods.

</details>