### PR TITLE
Remove local Claude lock file from tracking

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"74a00519-715a-4320-b8eb-06f1e90637fa","pid":3712889,"procStart":"15086839","acquiredAt":1780550558444}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ venv/
 # Tools
 .trunk
 .serena
+
+/.claude/


### PR DESCRIPTION
## Summary

Repo hygiene only — no code or behavior change.

`.claude/scheduled_tasks.lock` is a local Claude Code harness artifact that was accidentally swept into commit `090fb3e` (PR #1) via `git add -A` and merged to `develop`. This:
- untracks the file (`git rm --cached`, kept on disk for local tooling), and
- adds `/.claude/` to `.gitignore` so local tooling state can't be committed again.

No conflicts expected with any feature branches. Safe to merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- 로컬 아티팩트인 `.claude/scheduled_tasks.lock`의 추적을 중지하고, 유사한 파일이 커밋되지 않도록 `.claude` 디렉터리를 `.gitignore`에 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Stop tracking the local `.claude/scheduled_tasks.lock` artifact and add the `.claude` directory to `.gitignore` to prevent similar files from being committed.

</details>