### PR TITLE
Two-group effect-size table and volcano plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,31 @@ data = pd.read_csv("data.csv")
 
 plot.plot_heatmap(data)
 ```
+
+### Effect-size table & Volcano plot (two groups)
+
+`effect_size_table` builds a per-feature table (means, fold change, log2FC,
+Cohen's d, p-value, BH-adjusted p-value) for a two-group comparison.
+`plot_volcano` consumes that table — it does not compute statistics itself.
+
+```python
+from lmsstat import stat, plot
+import pandas as pd
+
+data = pd.read_csv("data.csv")  # exactly two groups
+
+eff = stat.effect_size_table(data)
+# choose the test and direction explicitly:
+# eff = stat.effect_size_table(data, p_source="u-test", group_order=["Ctrl", "Case"])
+# reuse a precomputed (unadjusted) allstats result:
+# eff = stat.effect_size_table(data, stats_res=stat.allstats(data, p_adj=False))
+
+eff.head()  # feature, group1, group2, mean1, mean2, fold_change, log2fc, cohens_d, p_value, p_adj
+
+plot.plot_volcano(eff)  # saves volcano_plot.png
+# plot.plot_volcano(eff, log2fc_threshold=1.0, p_threshold=0.05, use_adjusted=True)
+```
+
+`fold_change` / `log2fc` are reported only when both group means are strictly
+positive (raw, non-negative intensity data); otherwise they are `NaN` — no
+pseudocount is applied.

--- a/lmsstat/plot/__init__.py
+++ b/lmsstat/plot/__init__.py
@@ -1,1 +1,1 @@
-from ._plots import plot_pca, plot_box, plot_bar, plot_heatmap, plot_plsda
+from ._plots import plot_pca, plot_box, plot_bar, plot_heatmap, plot_plsda, plot_volcano

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -18,7 +18,7 @@ from plotnine import (
     scale_fill_manual, scale_x_discrete, scale_y_continuous,
     theme_classic, theme, geom_bar, geom_errorbar, labs,
     scale_color_manual, theme_minimal, element_text, stat_ellipse,
-    geom_text, scale_x_continuous
+    geom_text, scale_x_continuous, geom_hline, geom_vline
 )
 
 from ._utils import _annot, _pal, scaling, pca, plsda
@@ -1018,3 +1018,111 @@ def plot_plsda(
     vips = vip_df.sort_values(by="VIP", ascending=False)
 
     return g, r2x, r2y, q2, vips
+
+
+# ---------------------------------------------------------------------- #
+#                               volcano                                  #
+# ---------------------------------------------------------------------- #
+_VOLCANO_COLORS = {"Up": "#c0392b", "Down": "#2c7fb8", "NS": "#9e9e9e"}
+
+
+def plot_volcano(
+        eff_table: pd.DataFrame,
+        *,
+        log2fc_threshold: float = 1.0,
+        p_threshold: float = 0.05,
+        use_adjusted: bool = True,
+        save_path: str | Path = "volcano_plot.png",
+        dpi: int = 600,
+        point_size: float = 2.0,
+        show: bool = False,
+):
+    """
+    Draw a volcano plot from an :func:`lmsstat.stat.effect_size_table` result.
+
+    Consumes the table only — no statistics are computed here. x = log2fc,
+    y = -log10(p) where p is ``p_adj`` (``use_adjusted=True``) or ``p_value``.
+
+    Parameters
+    ----------
+    eff_table : DataFrame
+        Must contain ``log2fc``, ``p_value`` and ``p_adj`` columns.
+    log2fc_threshold : float
+        |log2fc| cutoff for the dashed vertical guides and Up/Down coloring (>= 0).
+    p_threshold : float
+        p-value cutoff for the dashed horizontal guide and significance (in [0, 1]).
+    use_adjusted : bool
+        Use ``p_adj`` (default) or the raw ``p_value`` for the y-axis and cutoff.
+
+    Returns
+    -------
+    plotnine.ggplot
+    """
+    if not (np.isfinite(log2fc_threshold) and log2fc_threshold >= 0):
+        raise ValueError("log2fc_threshold must be a finite value >= 0.")
+    if not (0.0 <= p_threshold <= 1.0):
+        raise ValueError("p_threshold must be in [0, 1].")
+
+    required = {"log2fc", "p_value", "p_adj"}
+    if not required.issubset(eff_table.columns):
+        missing = ", ".join(sorted(required - set(eff_table.columns)))
+        raise ValueError(f"eff_table is missing required column(s): {missing}.")
+
+    pcol = "p_adj" if use_adjusted else "p_value"
+    df = pd.DataFrame(
+        {
+            "log2fc": pd.to_numeric(eff_table["log2fc"], errors="coerce"),
+            "p": pd.to_numeric(eff_table[pcol], errors="coerce"),
+        }
+    )
+    # Drop features without a placeable x value (e.g. non-positive means).
+    df = df[np.isfinite(df["log2fc"].to_numpy(dtype=float))].copy()
+
+    p_vals = df["p"].to_numpy(dtype=float)
+    # Floor p at a tiny positive value so -log10(p) is never infinite.
+    p_floor = np.clip(np.nan_to_num(p_vals, nan=1.0), 1e-300, 1.0)
+    df["neglog10p"] = -np.log10(p_floor)
+
+    sig = p_floor <= p_threshold
+    lfc = df["log2fc"].to_numpy(dtype=float)
+    df["Significance"] = np.where(
+        sig & (lfc >= log2fc_threshold), "Up",
+        np.where(sig & (lfc <= -log2fc_threshold), "Down", "NS"),
+    )
+
+    present = [k for k in ("Up", "Down", "NS") if (df["Significance"] == k).any()]
+    cmap = {k: _VOLCANO_COLORS[k] for k in present}
+
+    g = (
+            ggplot(df, aes("log2fc", "neglog10p", color="Significance"))
+            + geom_point(size=point_size, alpha=0.7)
+            + scale_color_manual(values=cmap)
+            + labs(x="log2 fold change", y=f"-log10({pcol})")
+            + theme_minimal(base_size=11)
+            + theme(plot_title=element_text(weight="bold", ha="center"))
+    )
+
+    if log2fc_threshold > 0:
+        g += geom_vline(
+            xintercept=[-log2fc_threshold, log2fc_threshold],
+            linetype="dashed", color="grey", size=0.4,
+        )
+    if 0.0 < p_threshold <= 1.0:
+        g += geom_hline(
+            yintercept=-np.log10(p_threshold),
+            linetype="dashed", color="grey", size=0.4,
+        )
+
+    if save_path:
+        Path(save_path).parent.mkdir(exist_ok=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            fig = g.draw()
+            fig.savefig(save_path, dpi=dpi, bbox_inches="tight")
+        plt.close(fig)
+    if show:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            print(g)
+
+    return g

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -1075,12 +1075,22 @@ def plot_volcano(
             "p": pd.to_numeric(eff_table[pcol], errors="coerce"),
         }
     )
-    # Drop features without a placeable x value (e.g. non-positive means).
-    df = df[np.isfinite(df["log2fc"].to_numpy(dtype=float))].copy()
+    # Drop features that cannot be placed: non-finite log2fc (e.g. non-positive
+    # means) or non-finite p-value (would otherwise be drawn at a bogus y=0).
+    finite = (
+        np.isfinite(df["log2fc"].to_numpy(dtype=float))
+        & np.isfinite(df["p"].to_numpy(dtype=float))
+    )
+    df = df[finite].copy()
+    if df.empty:
+        raise ValueError(
+            "No plottable features: every row has a non-finite log2fc or "
+            f"{pcol}."
+        )
 
     p_vals = df["p"].to_numpy(dtype=float)
     # Floor p at a tiny positive value so -log10(p) is never infinite.
-    p_floor = np.clip(np.nan_to_num(p_vals, nan=1.0), 1e-300, 1.0)
+    p_floor = np.clip(p_vals, 1e-300, 1.0)
     df["neglog10p"] = -np.log10(p_floor)
 
     sig = p_floor <= p_threshold

--- a/lmsstat/stat/__init__.py
+++ b/lmsstat/stat/__init__.py
@@ -1,4 +1,5 @@
 from ._allstat import allstats
+from ._effect import effect_size_table
 from ._posthoc import dunn_test, scheffe_test, games_howell_test
 from ._preprocess import impute_missing, log_transform, normalize
 from ._utils import preprocess_data, p_adjust, correlation, scaling

--- a/lmsstat/stat/_effect.py
+++ b/lmsstat/stat/_effect.py
@@ -1,0 +1,143 @@
+"""
+Effect-size / fold-change table for two-group comparisons.
+
+`effect_size_table` owns the statistics (means, fold change, Cohen's d, and the
+chosen test's p-value plus a BH-adjusted p-value). `plot.plot_volcano` consumes
+the returned table; it does not compute anything itself.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+from scipy.stats import false_discovery_control
+
+from ._allstat import allstats
+from ._utils import _sanitize_pvalues_array, preprocess_data
+
+_P_KEY = {"t-test": "ttest", "u-test": "utest"}
+
+_COLUMNS = [
+    "feature", "group1", "group2", "mean1", "mean2",
+    "fold_change", "log2fc", "cohens_d", "p_value", "p_adj",
+]
+
+
+def _find_p_column(stats_res, group1, group2, key):
+    """Locate the (g1, g2)/(g2, g1) p-value column; two-sided p is directionless."""
+    for a, b in ((group1, group2), (group2, group1)):
+        col = f"({a}, {b})_{key}"
+        if col in stats_res.columns:
+            return col
+    raise ValueError(
+        f"No {key} p-value column for groups {group1!r}/{group2!r} in stats_res."
+    )
+
+
+def effect_size_table(data, stats_res=None, *, group_order=None, p_source="t-test"):
+    """
+    Build a per-feature effect-size table for a two-group comparison.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Wide table. Col0 = Sample, Col1 = Group, remaining = features. Must
+        contain exactly two groups.
+    stats_res : DataFrame, optional
+        Unadjusted ``allstats(data, p_adj=False)`` output. If None, it is
+        computed internally. The raw p-value is read from the selected test's
+        column; ``p_adj`` is always BH-adjusted within this table.
+    group_order : sequence of two str, optional
+        The two observed group labels in the desired (group1, group2) order.
+        Controls direction only: fold_change = mean2 / mean1 and the sign of
+        log2fc / cohens_d. Defaults to the sorted group order.
+    p_source : {"t-test", "u-test"}
+        Which two-group test's p-value to report. Defaults to "t-test".
+
+    Returns
+    -------
+    DataFrame with columns:
+        feature, group1, group2, mean1, mean2, fold_change, log2fc,
+        cohens_d, p_value, p_adj
+
+    Notes
+    -----
+    fold_change / log2fc are defined only when both group means are strictly
+    positive (raw, non-negative intensity data); otherwise both are NaN — no
+    pseudocount is invented. Cohen's d uses the pooled standard deviation.
+    """
+    if p_source not in _P_KEY:
+        raise ValueError("p_source must be 't-test' or 'u-test'.")
+    key = _P_KEY[p_source]
+
+    _, groups_split, metabolite_names = preprocess_data(data)
+    group_names = list(groups_split.groups.keys())
+    if len(group_names) != 2:
+        raise ValueError(
+            f"effect_size_table requires exactly two groups, got {len(group_names)}."
+        )
+
+    if group_order is None:
+        group1, group2 = group_names[0], group_names[1]
+    else:
+        group_order = [str(g) for g in group_order]
+        if len(group_order) != 2 or set(group_order) != set(group_names):
+            raise ValueError(
+                "group_order must contain exactly the two observed groups: "
+                f"{group_names}."
+            )
+        group1, group2 = group_order[0], group_order[1]
+
+    mat1 = groups_split.get_group(group1)[metabolite_names].to_numpy(dtype=float)
+    mat2 = groups_split.get_group(group2)[metabolite_names].to_numpy(dtype=float)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        mean1 = np.nanmean(mat1, axis=0)
+        mean2 = np.nanmean(mat2, axis=0)
+        var1 = np.nanvar(mat1, axis=0, ddof=1)
+        var2 = np.nanvar(mat2, axis=0, ddof=1)
+    n1 = np.sum(~np.isnan(mat1), axis=0)
+    n2 = np.sum(~np.isnan(mat2), axis=0)
+
+    # Fold change / log2FC: only when both group means are strictly positive.
+    both_pos = (mean1 > 0) & (mean2 > 0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = mean2 / mean1
+        fold_change = np.where(both_pos, ratio, np.nan)
+        log2fc = np.where(both_pos, np.log2(np.where(both_pos, ratio, 1.0)), np.nan)
+
+    # Cohen's d with pooled standard deviation.
+    df_pool = n1 + n2 - 2
+    with np.errstate(divide="ignore", invalid="ignore"):
+        s_pooled = np.sqrt(((n1 - 1) * var1 + (n2 - 1) * var2) / df_pool)
+    cohens_d = np.full(len(metabolite_names), np.nan, dtype=float)
+    usable = (df_pool > 0) & np.isfinite(s_pooled) & (s_pooled > 0)
+    cohens_d[usable] = (mean2[usable] - mean1[usable]) / s_pooled[usable]
+    # No spread but equal means → zero effect (e.g. a constant feature).
+    flat_equal = (df_pool > 0) & ~usable & np.isclose(mean1, mean2)
+    cohens_d[flat_equal] = 0.0
+
+    if stats_res is None:
+        stats_res = allstats(data, p_adj=False)
+    p_col = _find_p_column(stats_res, group1, group2, key)
+    p_value = _sanitize_pvalues_array(
+        stats_res.reindex(metabolite_names)[p_col].to_numpy(dtype=float)
+    )
+    p_adj = _sanitize_pvalues_array(false_discovery_control(p_value))
+
+    out = pd.DataFrame(
+        {
+            "feature": metabolite_names,
+            "group1": group1,
+            "group2": group2,
+            "mean1": mean1,
+            "mean2": mean2,
+            "fold_change": fold_change,
+            "log2fc": log2fc,
+            "cohens_d": cohens_d,
+            "p_value": p_value,
+            "p_adj": p_adj,
+        }
+    )
+    return out[_COLUMNS]

--- a/lmsstat/stat/_effect.py
+++ b/lmsstat/stat/_effect.py
@@ -107,10 +107,14 @@ def effect_size_table(data, stats_res=None, *, group_order=None, p_source="t-tes
         fold_change = np.where(both_pos, ratio, np.nan)
         log2fc = np.where(both_pos, np.log2(np.where(both_pos, ratio, 1.0)), np.nan)
 
-    # Cohen's d with pooled standard deviation.
+    # Cohen's d with pooled standard deviation. A group with a single finite
+    # value (n <= 1) has undefined variance; it contributes zero sum-of-squares
+    # rather than propagating NaN, so d stays computable from the other group.
     df_pool = n1 + n2 - 2
+    ss1 = np.where(n1 > 1, (n1 - 1) * np.nan_to_num(var1, nan=0.0), 0.0)
+    ss2 = np.where(n2 > 1, (n2 - 1) * np.nan_to_num(var2, nan=0.0), 0.0)
     with np.errstate(divide="ignore", invalid="ignore"):
-        s_pooled = np.sqrt(((n1 - 1) * var1 + (n2 - 1) * var2) / df_pool)
+        s_pooled = np.sqrt((ss1 + ss2) / df_pool)
     cohens_d = np.full(len(metabolite_names), np.nan, dtype=float)
     usable = (df_pool > 0) & np.isfinite(s_pooled) & (s_pooled > 0)
     cohens_d[usable] = (mean2[usable] - mean1[usable]) / s_pooled[usable]
@@ -120,6 +124,12 @@ def effect_size_table(data, stats_res=None, *, group_order=None, p_source="t-tes
 
     if stats_res is None:
         stats_res = allstats(data, p_adj=False)
+    missing = [f for f in metabolite_names if f not in stats_res.index]
+    if missing:
+        raise ValueError(
+            "stats_res is missing p-values for "
+            f"{len(missing)} feature(s), e.g. {missing[:5]}."
+        )
     p_col = _find_p_column(stats_res, group1, group2, key)
     p_value = _sanitize_pvalues_array(
         stats_res.reindex(metabolite_names)[p_col].to_numpy(dtype=float)

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -10,9 +10,11 @@ from lmsstat.plot._plots import (
     plot_heatmap,
     plot_box,
     plot_bar,
+    plot_volcano,
     FOLDER,
 )
 from lmsstat.stat._allstat import allstats
+from lmsstat.stat._effect import effect_size_table
 
 
 pytestmark = pytest.mark.slow
@@ -209,3 +211,44 @@ class TestPlotBar:
         from pathlib import Path
         created = list(Path(outdir).glob("*.png"))
         assert len(created) > 0
+
+
+# ── plot_volcano ────────────────────────────────────────────────────────
+
+class TestPlotVolcano:
+    def test_returns_object_and_saves_png(self, two_group_data, tmp_path):
+        et = effect_size_table(two_group_data)
+        save = tmp_path / "volcano.png"
+        g = plot_volcano(et, save_path=str(save))
+        assert g is not None
+        assert save.exists()
+        with open(save, "rb") as f:
+            assert f.read(4) == b"\x89PNG"
+
+    def test_use_adjusted_false_runs(self, two_group_data, tmp_path):
+        et = effect_size_table(two_group_data)
+        save = tmp_path / "volcano_raw.png"
+        plot_volcano(et, use_adjusted=False, save_path=str(save))
+        assert save.exists()
+
+    def test_missing_columns_raises(self):
+        with pytest.raises(ValueError):
+            plot_volcano(pd.DataFrame({"x": [1.0], "y": [2.0]}))
+
+    def test_invalid_log2fc_threshold_raises(self, two_group_data):
+        et = effect_size_table(two_group_data)
+        with pytest.raises(ValueError):
+            plot_volcano(et, log2fc_threshold=-1.0)
+
+    def test_invalid_p_threshold_raises(self, two_group_data):
+        et = effect_size_table(two_group_data)
+        with pytest.raises(ValueError):
+            plot_volcano(et, p_threshold=2.0)
+
+    def test_zero_pvalue_no_inf(self, two_group_data, tmp_path):
+        et = effect_size_table(two_group_data)
+        et.loc[et.index[0], "p_adj"] = 0.0  # force a zero p-value
+        save = tmp_path / "volcano_zero.png"
+        # Should floor p for plotting and not raise on -log10(0).
+        plot_volcano(et, save_path=str(save))
+        assert save.exists()

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -252,3 +252,18 @@ class TestPlotVolcano:
         # Should floor p for plotting and not raise on -log10(0).
         plot_volcano(et, save_path=str(save))
         assert save.exists()
+
+    def test_drops_nonfinite_pvalue_rows(self, two_group_data, tmp_path):
+        et = effect_size_table(two_group_data)
+        et.loc[et.index[0], "p_adj"] = np.nan  # invalid p → must be dropped, not plotted at y=0
+        save = tmp_path / "volcano_partial.png"
+        g = plot_volcano(et, save_path=str(save))
+        # The plotted data must exclude the NaN-p feature.
+        assert len(g.data) == len(et) - 1
+        assert save.exists()
+
+    def test_all_nonplottable_raises(self, two_group_data):
+        et = effect_size_table(two_group_data)
+        et["p_adj"] = np.nan
+        with pytest.raises(ValueError):
+            plot_volcano(et)

--- a/tests/test_stat_effect.py
+++ b/tests/test_stat_effect.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from lmsstat.stat._effect import effect_size_table
+from lmsstat.stat import allstats
+
+EXPECTED_COLS = [
+    "feature", "group1", "group2", "mean1", "mean2",
+    "fold_change", "log2fc", "cohens_d", "p_value", "p_adj",
+]
+
+
+@pytest.fixture()
+def two_group_known():
+    # A: Met_0 mean=2 (sd=1), Met_1 constant=10
+    # B: Met_0 mean=5 (sd=1), Met_1 constant=10
+    return pd.DataFrame(
+        {
+            "Sample": [f"S{i}" for i in range(6)],
+            "Group": ["A", "A", "A", "B", "B", "B"],
+            "Met_0": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "Met_1": [10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
+        }
+    )
+
+
+class TestEffectSizeTable:
+    def test_columns_and_order(self, two_group_known):
+        out = effect_size_table(two_group_known)
+        assert list(out.columns) == EXPECTED_COLS
+
+    def test_one_row_per_feature(self, two_group_known):
+        out = effect_size_table(two_group_known)
+        assert out["feature"].tolist() == ["Met_0", "Met_1"]
+
+    def test_raises_on_three_groups(self, three_group_data):
+        with pytest.raises(ValueError):
+            effect_size_table(three_group_data)
+
+    def test_group_labels_sorted_default(self, two_group_known):
+        out = effect_size_table(two_group_known)
+        assert (out["group1"] == "A").all()
+        assert (out["group2"] == "B").all()
+
+    def test_means(self, two_group_known):
+        out = effect_size_table(two_group_known).set_index("feature")
+        assert out.loc["Met_0", "mean1"] == pytest.approx(2.0)
+        assert out.loc["Met_0", "mean2"] == pytest.approx(5.0)
+
+    def test_fold_change_and_log2fc(self, two_group_known):
+        out = effect_size_table(two_group_known).set_index("feature")
+        assert out.loc["Met_0", "fold_change"] == pytest.approx(2.5)
+        assert out.loc["Met_0", "log2fc"] == pytest.approx(np.log2(2.5))
+
+    def test_cohens_d(self, two_group_known):
+        out = effect_size_table(two_group_known).set_index("feature")
+        # s_pooled = sqrt((2*1 + 2*1)/4) = 1 ; d = (5-2)/1 = 3
+        assert out.loc["Met_0", "cohens_d"] == pytest.approx(3.0)
+
+    def test_constant_feature(self, two_group_known):
+        out = effect_size_table(two_group_known).set_index("feature")
+        assert out.loc["Met_1", "fold_change"] == pytest.approx(1.0)
+        assert out.loc["Met_1", "log2fc"] == pytest.approx(0.0)
+        assert out.loc["Met_1", "cohens_d"] == pytest.approx(0.0)
+
+    def test_group_order_flips_sign(self, two_group_known):
+        base = effect_size_table(two_group_known).set_index("feature")
+        flip = effect_size_table(two_group_known, group_order=["B", "A"]).set_index("feature")
+        assert flip.loc["Met_0", "cohens_d"] == pytest.approx(-base.loc["Met_0", "cohens_d"])
+        assert flip.loc["Met_0", "log2fc"] == pytest.approx(-base.loc["Met_0", "log2fc"])
+        assert flip.loc["Met_0", "group1"] == "B"
+        assert flip.loc["Met_0", "group2"] == "A"
+
+    def test_invalid_group_order_raises(self, two_group_known):
+        with pytest.raises(ValueError):
+            effect_size_table(two_group_known, group_order=["A", "C"])
+        with pytest.raises(ValueError):
+            effect_size_table(two_group_known, group_order=["A"])
+
+    def test_invalid_p_source_raises(self, two_group_known):
+        with pytest.raises(ValueError):
+            effect_size_table(two_group_known, p_source="anova")
+
+    def test_p_value_matches_allstats_ttest(self, two_group_known):
+        st = allstats(two_group_known, p_adj=False)
+        out = effect_size_table(two_group_known).set_index("feature")
+        col = [c for c in st.columns if c.endswith("_ttest")][0]
+        assert out.loc["Met_0", "p_value"] == pytest.approx(st.loc["Met_0", col])
+
+    def test_p_source_utest_in_range(self, two_group_known):
+        out = effect_size_table(two_group_known, p_source="u-test")
+        assert (out["p_value"] >= 0).all() and (out["p_value"] <= 1).all()
+
+    def test_p_adj_ge_p_value(self, two_group_known):
+        out = effect_size_table(two_group_known)
+        assert np.all(out["p_adj"].to_numpy() + 1e-12 >= out["p_value"].to_numpy())
+
+    def test_stats_res_path_matches_internal(self, two_group_known):
+        st = allstats(two_group_known, p_adj=False)
+        a = effect_size_table(two_group_known)
+        b = effect_size_table(two_group_known, stats_res=st)
+        pd.testing.assert_frame_equal(a, b)
+
+    def test_does_not_mutate_input(self, two_group_known):
+        before = two_group_known.copy(deep=True)
+        _ = effect_size_table(two_group_known)
+        pd.testing.assert_frame_equal(two_group_known, before)
+
+    def test_nonpositive_mean_nan_fold_change(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c", "d"], "Group": ["A", "A", "B", "B"],
+             "Met_0": [-1.0, -2.0, 3.0, 4.0]}  # group A mean = -1.5 (<= 0)
+        )
+        out = effect_size_table(df).set_index("feature")
+        assert np.isnan(out.loc["Met_0", "fold_change"])
+        assert np.isnan(out.loc["Met_0", "log2fc"])
+
+    def test_nan_tolerant(self):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c", "d"], "Group": ["A", "A", "B", "B"],
+             "Met_0": [1.0, np.nan, 4.0, 6.0]}  # A mean=1, B mean=5
+        )
+        out = effect_size_table(df).set_index("feature")
+        assert out.loc["Met_0", "mean1"] == pytest.approx(1.0)
+        assert out.loc["Met_0", "mean2"] == pytest.approx(5.0)

--- a/tests/test_stat_effect.py
+++ b/tests/test_stat_effect.py
@@ -124,3 +124,23 @@ class TestEffectSizeTable:
         out = effect_size_table(df).set_index("feature")
         assert out.loc["Met_0", "mean1"] == pytest.approx(1.0)
         assert out.loc["Met_0", "mean2"] == pytest.approx(5.0)
+
+    def test_cohens_d_with_singleton_group(self):
+        # Group A has a single finite value (n1 == 1): its variance is undefined,
+        # but Cohen's d should still be computable from group B's spread.
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c", "d"], "Group": ["A", "A", "B", "B"],
+             "Met_0": [2.0, np.nan, 4.0, 6.0]}  # A: one finite (2.0); B: [4, 6]
+        )
+        out = effect_size_table(df).set_index("feature")
+        d = out.loc["Met_0", "cohens_d"]
+        assert np.isfinite(d)
+        # ss_A = 0 (n1 == 1); ss_B = (2-1)*var_B = 2; df_pool = 1+2-2 = 1
+        # s_pooled = sqrt((0 + 2) / 1) = sqrt(2); d = (5 - 2) / sqrt(2)
+        assert d == pytest.approx(3.0 / np.sqrt(2.0))
+
+    def test_stats_res_missing_feature_raises(self, two_group_known):
+        st = allstats(two_group_known, p_adj=False)
+        st_partial = st.drop(index="Met_1")  # omit a feature present in data
+        with pytest.raises(ValueError):
+            effect_size_table(two_group_known, stats_res=st_partial)


### PR DESCRIPTION
## Summary

Implements the volcano + effect-size feature per the agreed spec. Branches off the freshly-merged `develop` (after #1/#2/#3).

### `stat.effect_size_table(data, stats_res=None, *, group_order=None, p_source="t-test")`
One row per feature: `feature, group1, group2, mean1, mean2, fold_change, log2fc, cohens_d, p_value, p_adj`.
- **Two-group only** (raises otherwise); reuses `preprocess_data` so group sorting / numeric coercion / dropped-missing-group behavior matches the rest of `stat`.
- `effect_size_table` **owns the statistics**; `stats_res` defaults to `allstats(data, p_adj=False)`. The internal and supplied-`stats_res` paths produce identical tables.
- `p_value` from the selected test column (`t-test`/`u-test`); column lookup accepts either `(g1,g2)` or `(g2,g1)` orientation since two-sided p is directionless. `p_adj` is BH-adjusted **within the table**.
- `group_order` controls **direction only** (must be the two observed groups; flips sign of `log2fc`/`cohens_d`).
- `fold_change`/`log2fc` only when **both group means are strictly positive** — no pseudocount; otherwise `NaN`. Cohen's d uses the pooled SD.

### `plot.plot_volcano(eff_table, *, log2fc_threshold=1.0, p_threshold=0.05, use_adjusted=True, ...)`
- **Consumes the table only** — computes no statistics.
- Floors `p` at a tiny positive value so `-log10(p)` is never infinite.
- Validates thresholds (`log2fc_threshold >= 0`, `p_threshold ∈ [0,1]`); dashed guides; Up/Down/NS coloring.
- **No feature labels in v1** (deferred to avoid label-collision scope).

### Out of scope (by design)
Multi-group, pathway/export, label-collision handling, interactive plots.

### Tests
24 new tests (18 `effect_size_table` + 6 `plot_volcano`); full suite **238 passing** locally (conda env `lmsstat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

두 그룹 효과 크기(effect size) 요약 테이블과 해당하는 볼케이노 플롯 시각화를 추가하고, 관련 문서 및 테스트를 포함합니다.

New Features:
- 두 그룹 비교를 위해 각 피처별 평균, fold change, log2 fold change, Cohen’s d, p-value를 계산하는 `stat.effect_size_table`을(를) 도입합니다.
- 효과 크기 테이블로부터 볼케이노 플롯을 생성하고, 임계값 및 유의성 색상을 설정 가능하도록 하는 `plot.plot_volcano`를 추가합니다.

Enhancements:
- README에 두 그룹 효과 크기 테이블과 볼케이노 플롯 워크플로를 문서화하고, 사용 예제 및 파라미터 옵션을 포함합니다.

Tests:
- 그룹 처리, 효과 크기 계산, p-value 동작, 엣지 케이스에 대한 강건성을 포함하여 `effect_size_table`에 대한 단위 테스트를 추가합니다.
- 인자 검증, 필수 컬럼, p-flooring 동작, PNG 출력 생성 여부를 검증하기 위한 `plot_volcano` 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a two-group effect-size summary table and corresponding volcano plot visualization, along with documentation and tests.

New Features:
- Introduce stat.effect_size_table to compute per-feature means, fold change, log2 fold change, Cohen’s d, and p-values for two-group comparisons.
- Add plot.plot_volcano to generate a volcano plot from an effect-size table, with configurable thresholds and significance coloring.

Enhancements:
- Document the two-group effect-size table and volcano plot workflow in the README, including usage examples and parameter options.

Tests:
- Add unit tests for effect_size_table covering group handling, effect-size calculations, p-value behavior, and robustness to edge cases.
- Add tests for plot_volcano to validate argument checking, required columns, p-flooring behavior, and PNG output generation.

</details>