### PR TITLE
Add correlation heat map plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ data = pd.read_csv("data.csv")
 plot.plot_heatmap(data)
 ```
 
+### Correlation plot
+
+Draws a clustered correlation heat map (feature×feature by default). The color
+scale is fixed to `[-1, 1]` so plots stay comparable across runs. Returns the
+seaborn object (`ClusterGrid` when clustered, `Axes` otherwise) and saves a PNG.
+
+```python
+from lmsstat import plot
+import pandas as pd
+
+data = pd.read_csv("data.csv")
+
+cg = plot.plot_correlation(data)  # axis="metabolite", method="pearson", clustered
+# ax = plot.plot_correlation(data, axis="sample", method="spearman", cluster=False)
+# plot.plot_correlation(data, annot=True)  # cell values — for small matrices only
+```
+
 ### Effect-size table & Volcano plot (two groups)
 
 `effect_size_table` builds a per-feature table (means, fold change, log2FC,

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ plot.plot_heatmap(data)
 
 ### Correlation plot
 
-Draws a clustered correlation heat map (feature×feature by default). The color
+Draws a clustered correlation heatmap (feature×feature by default). The color
 scale is fixed to `[-1, 1]` so plots stay comparable across runs. Returns the
 seaborn object (`ClusterGrid` when clustered, `Axes` otherwise) and saves a PNG.
 

--- a/lmsstat/plot/__init__.py
+++ b/lmsstat/plot/__init__.py
@@ -1,1 +1,1 @@
-from ._plots import plot_pca, plot_box, plot_bar, plot_heatmap, plot_plsda, plot_volcano
+from ._plots import plot_pca, plot_box, plot_bar, plot_heatmap, plot_plsda, plot_volcano, plot_correlation

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -1152,7 +1152,7 @@ def plot_correlation(
         cluster: bool = True,
         annot: bool = False,
         cmap: str = "coolwarm",
-        out_path: str | Path = "correlation_plot.png",
+        out_path: str | Path | None = "correlation_plot.png",
         figsize: tuple = (10, 8),
         dpi: int = 600,
         label_size: int = 8,
@@ -1165,7 +1165,8 @@ def plot_correlation(
     data : DataFrame
         Wide table. Col0 = Sample, Col1 = Group, remaining = features.
     axis : {"metabolite", "sample"}
-        Correlate features (default) or samples.
+        Correlate features (default) or samples. With ``"sample"`` the axes are
+        labelled with the ``Sample`` column rather than the row position.
     method : {"pearson", "spearman", "kendall"}
         Correlation method.
     cluster : bool
@@ -1177,17 +1178,41 @@ def plot_correlation(
     cmap : str
         Diverging colormap; the scale is fixed to [-1, 1] centered at 0 so plots
         are visually comparable across runs.
+    out_path : str | Path | None
+        Where to save the PNG. If None, nothing is written and the figure object
+        is returned for further use (e.g. in a notebook).
 
     Returns
     -------
     seaborn.matrix.ClusterGrid (cluster=True) or matplotlib.axes.Axes (cluster=False)
     """
     if method not in _CORR_METHODS:
-        raise ValueError("method must be 'pearson', 'spearman', or 'kendall'.")
+        raise ValueError(f"method must be one of {_CORR_METHODS}.")
 
     corr = correlation(data, axis=axis, method=method)
 
+    # stat.correlation drops Sample/Group then transposes for the sample axis,
+    # so the axes come back as row positions; relabel them with the Sample IDs.
+    if str(axis).lower() == "sample":
+        sample_ids = ensure_sample_group_columns(data)["Sample"].astype(str).to_numpy()
+        corr.index = sample_ids
+        corr.columns = sample_ids
+
     if cluster:
+        # clustermap rejects non-finite distances; constant features/samples
+        # produce all-NaN correlation rows/columns. Drop those, then verify a
+        # clusterable, finite matrix remains.
+        off_diagonal = corr.to_numpy(dtype=float).copy()
+        np.fill_diagonal(off_diagonal, np.nan)
+        keep = ~np.isnan(off_diagonal).all(axis=1)
+        if not keep.all():
+            labels = corr.index[keep]
+            corr = corr.loc[labels, labels]
+        if corr.shape[0] < 2 or not np.isfinite(corr.to_numpy(dtype=float)).all():
+            raise ValueError(
+                "Not enough rows/columns with finite correlations to cluster "
+                "(constant or all-NaN rows/columns were dropped). Try cluster=False."
+            )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             cg = sns.clustermap(
@@ -1210,10 +1235,10 @@ def plot_correlation(
         )
         result = ax
 
-    ax.set_xticklabels(ax.get_xticklabels(), rotation=90, ha="right", fontsize=label_size)
-    ax.set_yticklabels(ax.get_yticklabels(), rotation=0, va="center", fontsize=label_size)
+    plt.setp(ax.get_xticklabels(), rotation=90, ha="right", fontsize=label_size)
+    plt.setp(ax.get_yticklabels(), rotation=0, va="center", fontsize=label_size)
 
-    if out_path:
+    if out_path is not None:
         Path(out_path).parent.mkdir(exist_ok=True)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -22,7 +22,7 @@ from plotnine import (
 )
 
 from ._utils import _annot, _pal, scaling, pca, plsda
-from ..stat._utils import ensure_sample_group_columns
+from ..stat._utils import ensure_sample_group_columns, correlation
 
 import gc
 import warnings
@@ -1136,3 +1136,87 @@ def plot_volcano(
             print(g)
 
     return g
+
+
+# ---------------------------------------------------------------------- #
+#                            correlation map                             #
+# ---------------------------------------------------------------------- #
+_CORR_METHODS = ("pearson", "spearman", "kendall")
+
+
+def plot_correlation(
+        data: pd.DataFrame,
+        *,
+        axis: str = "metabolite",
+        method: str = "pearson",
+        cluster: bool = True,
+        annot: bool = False,
+        cmap: str = "coolwarm",
+        out_path: str | Path = "correlation_plot.png",
+        figsize: tuple = (10, 8),
+        dpi: int = 600,
+        label_size: int = 8,
+):
+    """
+    Draw a correlation heat map from :func:`lmsstat.stat.correlation`.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Wide table. Col0 = Sample, Col1 = Group, remaining = features.
+    axis : {"metabolite", "sample"}
+        Correlate features (default) or samples.
+    method : {"pearson", "spearman", "kendall"}
+        Correlation method.
+    cluster : bool
+        If True, hierarchically cluster rows/columns (seaborn ``clustermap``)
+        and return the ``ClusterGrid``. If False, draw a plain ordered heat map
+        and return the matplotlib ``Axes``.
+    annot : bool
+        Write the correlation value in each cell. Intended for small matrices.
+    cmap : str
+        Diverging colormap; the scale is fixed to [-1, 1] centered at 0 so plots
+        are visually comparable across runs.
+
+    Returns
+    -------
+    seaborn.matrix.ClusterGrid (cluster=True) or matplotlib.axes.Axes (cluster=False)
+    """
+    if method not in _CORR_METHODS:
+        raise ValueError("method must be 'pearson', 'spearman', or 'kendall'.")
+
+    corr = correlation(data, axis=axis, method=method)
+
+    if cluster:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            cg = sns.clustermap(
+                corr,
+                cmap=cmap, vmin=-1, vmax=1, center=0,
+                figsize=figsize, annot=annot,
+                xticklabels=True, yticklabels=True,
+                cbar_kws={"label": f"{method} r"},
+            )
+        ax = cg.ax_heatmap
+        result, fig = cg, cg.figure
+    else:
+        fig, ax = plt.subplots(figsize=figsize)
+        sns.heatmap(
+            corr,
+            cmap=cmap, vmin=-1, vmax=1, center=0,
+            annot=annot, square=True, ax=ax,
+            xticklabels=True, yticklabels=True,
+            cbar_kws={"label": f"{method} r"},
+        )
+        result = ax
+
+    ax.set_xticklabels(ax.get_xticklabels(), rotation=90, ha="right", fontsize=label_size)
+    ax.set_yticklabels(ax.get_yticklabels(), rotation=0, va="center", fontsize=label_size)
+
+    if out_path:
+        Path(out_path).parent.mkdir(exist_ok=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            fig.savefig(out_path, dpi=dpi, bbox_inches="tight")
+
+    return result

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -11,6 +11,7 @@ from lmsstat.plot._plots import (
     plot_box,
     plot_bar,
     plot_volcano,
+    plot_correlation,
     FOLDER,
 )
 from lmsstat.stat._allstat import allstats
@@ -267,3 +268,50 @@ class TestPlotVolcano:
         et["p_adj"] = np.nan
         with pytest.raises(ValueError):
             plot_volcano(et)
+
+
+# ── plot_correlation ──────────────────────────────────────────────────────
+
+class TestPlotCorrelation:
+    def test_cluster_returns_clustergrid_and_saves(self, two_group_data, tmp_path):
+        from seaborn.matrix import ClusterGrid
+        out = tmp_path / "corr.png"
+        cg = plot_correlation(two_group_data, out_path=str(out))
+        assert isinstance(cg, ClusterGrid)
+        assert out.exists()
+        with open(out, "rb") as f:
+            assert f.read(4) == b"\x89PNG"
+
+    def test_no_cluster_returns_axes_and_saves(self, two_group_data, tmp_path):
+        import matplotlib.axes
+        out = tmp_path / "corr_nc.png"
+        ax = plot_correlation(two_group_data, cluster=False, out_path=str(out))
+        assert isinstance(ax, matplotlib.axes.Axes)
+        assert out.exists()
+
+    def test_axis_metabolite_shape(self, two_group_data, tmp_path):
+        # 5 metabolite columns → 5×5 correlation matrix
+        cg = plot_correlation(two_group_data, axis="metabolite", out_path=str(tmp_path / "m.png"))
+        assert cg.data2d.shape == (5, 5)
+
+    def test_axis_sample_shape(self, two_group_data, tmp_path):
+        # 20 samples → 20×20 correlation matrix
+        cg = plot_correlation(two_group_data, axis="sample", out_path=str(tmp_path / "s.png"))
+        assert cg.data2d.shape == (20, 20)
+
+    def test_invalid_axis_raises(self, two_group_data, tmp_path):
+        with pytest.raises(ValueError):
+            plot_correlation(two_group_data, axis="bogus", out_path=str(tmp_path / "x.png"))
+
+    def test_invalid_method_raises(self, two_group_data, tmp_path):
+        with pytest.raises(ValueError):
+            plot_correlation(two_group_data, method="bogus", out_path=str(tmp_path / "x.png"))
+
+    def test_annot_small_matrix(self, tmp_path):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "M0": [1.0, 2.0, 3.0], "M1": [3.0, 2.0, 1.5]}
+        )
+        out = tmp_path / "annot.png"
+        plot_correlation(df, annot=True, out_path=str(out))
+        assert out.exists()

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -315,3 +315,34 @@ class TestPlotCorrelation:
         out = tmp_path / "annot.png"
         plot_correlation(df, annot=True, out_path=str(out))
         assert out.exists()
+
+    def test_cluster_drops_constant_feature(self, tmp_path):
+        df = pd.DataFrame(
+            {"Sample": [f"S{i}" for i in range(6)], "Group": ["A"] * 3 + ["B"] * 3,
+             "M0": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+             "M1": [2.0, 1.0, 4.0, 3.0, 6.0, 5.0],
+             "M2": [5.0] * 6}  # constant → NaN correlations, must be dropped
+        )
+        cg = plot_correlation(df, out_path=str(tmp_path / "c.png"))
+        assert "M2" not in list(cg.data2d.index)
+        assert cg.data2d.shape == (2, 2)
+
+    def test_cluster_too_few_finite_raises(self, tmp_path):
+        df = pd.DataFrame(
+            {"Sample": ["a", "b", "c"], "Group": ["A", "A", "B"],
+             "M0": [1.0, 2.0, 3.0], "M1": [5.0] * 3, "M2": [7.0] * 3}  # two constants
+        )
+        with pytest.raises(ValueError):
+            plot_correlation(df, out_path=str(tmp_path / "x.png"))
+
+    def test_sample_axis_labels_are_sample_ids(self, two_group_data, tmp_path):
+        cg = plot_correlation(two_group_data, axis="sample", out_path=str(tmp_path / "s.png"))
+        sample_ids = set(two_group_data.iloc[:, 0].astype(str))
+        assert set(map(str, cg.data2d.index)) == sample_ids
+
+    def test_out_path_none_no_save(self, two_group_data, tmp_path, monkeypatch):
+        from seaborn.matrix import ClusterGrid
+        monkeypatch.chdir(tmp_path)
+        cg = plot_correlation(two_group_data, out_path=None)
+        assert isinstance(cg, ClusterGrid)
+        assert not (tmp_path / "correlation_plot.png").exists()


### PR DESCRIPTION
## Summary

Small visualization PR (per the agreed tempo). Adds the plotting layer on top of the existing `stat.correlation()`.

### `plot.plot_correlation(data, *, axis="metabolite", method="pearson", cluster=True, annot=False, cmap="coolwarm", out_path="correlation_plot.png", figsize=(10,8), dpi=600, label_size=8)`
- Wraps `stat.correlation(data, axis, method)` — no new statistics.
- `axis` defaults to **`"metabolite"`** (feature×feature; `"sample"` supported).
- `method` validated explicitly as `{"pearson","spearman","kendall"}` before delegating (v1 keeps it simple — no callables).
- **Fixed `[-1, 1]` color scale centered at 0** so plots are visually comparable across runs.
- Returns the seaborn object: **`ClusterGrid`** when `cluster=True`, **`Axes`** when `cluster=False`. Saves a PNG by default in both cases.
- `annot=True` intended for small matrices only.

### Out of scope (by design)
Significance masking, partial correlation, network/graph layout, large-matrix annotation ergonomics.

### Tests
7 new tests (ClusterGrid/Axes return types + PNG save, metabolite vs sample matrix dims, invalid axis/method, annot on a tiny matrix); full suite **249 passing** locally (conda env `lmsstat`). Visually verified clustering on a synthetic block-correlated dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

기존 상관관계 통계 함수를 감싸는 상관관계 히트맵 플로팅 헬퍼를 추가하고, 이를 퍼블릭 플로팅 API를 통해 노출합니다.

새로운 기능:
- 탭уляр 데이터로부터 클러스터링된 또는 일반 상관관계 히트맵을 그리기 위한 `plot_correlation`을 제공하며, 축(axis), 계산 방법(method), 주석(annotation) 옵션을 구성할 수 있습니다.

문서:
- 새로운 상관관계 플롯 헬퍼와 그 사용법을 README에 문서화하고, 기본 동작과 커스터마이징 옵션을 포함합니다.

테스트:
- `plot_correlation`의 출력(ClusterGrid vs Axes), PNG 저장, 서로 다른 축 설정에 따른 행렬 차원, 입력값 검증, 주석이 달린 작은 행렬에 대한 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a correlation heat map plotting helper that wraps the existing correlation statistics and expose it via the public plotting API.

New Features:
- Provide plot_correlation for drawing clustered or plain correlation heat maps from tabular data with configurable axis, method, and annotation options.

Documentation:
- Document the new correlation plot helper and its usage in the README, including default behavior and customization options.

Tests:
- Add tests covering plot_correlation outputs (ClusterGrid vs Axes), PNG saving, matrix dimensions for different axes, input validation, and annotated small matrices.

</details>