### PR TITLE
Ignore default plot output artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ venv/
 .serena
 
 /.claude/
+
+# Default plot outputs (pca_plot.png, pls_da_plot.png, volcano_plot.png,
+# correlation_plot.png, heatmap.png, and the box/bar plot folders)
+*_plot.png
+heatmap.png
+/boxplot/
+/barplot/


### PR DESCRIPTION
## Summary

Tiny hygiene PR — `.gitignore` only, no code change.

The plotting functions save to fixed default paths in the working directory (`pca_plot.png`, `pls_da_plot.png`, `volcano_plot.png`, `correlation_plot.png`, `heatmap.png`) plus the `boxplot/` / `barplot/` folders. A `volcano_plot.png` had already slipped into the working tree once during this work. This ignores those default outputs so they can't be committed by accident.

Scoped patterns (`*_plot.png`, `heatmap.png`, `/boxplot/`, `/barplot/`) — **not** a blanket `*.png` ignore, so genuine image assets stay tracked. Verified: all five default outputs + the two folders are ignored, while `lmsstat/logo.png` is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- 기본 플롯 이미지 출력물과 플롯 관련 폴더가 버전 관리에 포함되지 않도록 `.gitignore` 항목을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Add .gitignore entries to exclude default plot image outputs and plot-related folders from version control

</details>