### PR TITLE
Add VIP bar plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ print(f"R2X: {plsda_plt[1]}, R2Y: {plsda_plt[2]}, Q2: {plsda_plt[3]}")  # R2, Q2
 print(plsda_plt[4].head())  # VIP ranking (DataFrame)
 ```
 
+### VIP plot
+
+Consumes the VIP table from PLS-DA (`plot_plsda(...)[4]`) and draws the top
+features as a horizontal bar chart. The dashed line marks `vip_threshold`
+(default 1.0); bars are split at `VIP >= vip_threshold`.
+
+```python
+from lmsstat import plot
+import pandas as pd
+
+data = pd.read_csv("data.csv")
+
+vip = plot.plot_plsda(data, n_components=2)[4]  # VIP DataFrame
+plot.plot_vip(vip)                              # top 20 by VIP, saves vip_plot.png
+# plot.plot_vip(vip, top_n=10, vip_threshold=1.5)
+```
+
 ### Box plot, Bar plot
 각각 현재 작업 디렉토리 밑에 만들어진 boxplot, barplot 폴더에 자동으로 저장됨.
 

--- a/lmsstat/plot/__init__.py
+++ b/lmsstat/plot/__init__.py
@@ -1,1 +1,1 @@
-from ._plots import plot_pca, plot_box, plot_bar, plot_heatmap, plot_plsda, plot_volcano, plot_correlation
+from ._plots import plot_pca, plot_box, plot_bar, plot_heatmap, plot_plsda, plot_volcano, plot_correlation, plot_vip

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -18,7 +18,8 @@ from plotnine import (
     scale_fill_manual, scale_x_discrete, scale_y_continuous,
     theme_classic, theme, geom_bar, geom_errorbar, labs,
     scale_color_manual, theme_minimal, element_text, stat_ellipse,
-    geom_text, scale_x_continuous, geom_hline, geom_vline
+    geom_text, scale_x_continuous, geom_hline, geom_vline,
+    geom_col, coord_flip
 )
 
 from ._utils import _annot, _pal, scaling, pca, plsda
@@ -1245,3 +1246,104 @@ def plot_correlation(
             fig.savefig(out_path, dpi=dpi, bbox_inches="tight")
 
     return result
+
+
+# ---------------------------------------------------------------------- #
+#                                VIP plot                                #
+# ---------------------------------------------------------------------- #
+def plot_vip(
+        vip: pd.DataFrame,
+        *,
+        top_n: int = 20,
+        vip_threshold: float = 1.0,
+        color_by_threshold: bool = True,
+        save_path: str | Path = "vip_plot.png",
+        dpi: int = 600,
+        figsize: tuple = (8, 6),
+        show: bool = False,
+):
+    """
+    Draw a VIP bar chart from a PLS-DA VIP table.
+
+    Pure consumer of the ``VIP`` table produced by
+    :func:`lmsstat.stat` PLS-DA (``vip_df``: a DataFrame indexed by feature with
+    a ``VIP`` column). Computes no statistics.
+
+    Parameters
+    ----------
+    vip : DataFrame
+        Indexed by feature name, with a ``VIP`` column. Non-finite VIP values
+        are dropped; a ValueError is raised if none remain.
+    top_n : int
+        Number of top features (by VIP, descending) to show. Must be a positive
+        integer; if it exceeds the number of features, all are shown.
+    vip_threshold : float
+        Reference cutoff (finite, non-negative). Drawn as a dashed line; with
+        ``color_by_threshold`` bars are split at ``VIP >= vip_threshold``.
+
+    Returns
+    -------
+    plotnine.ggplot
+    """
+    if isinstance(top_n, bool) or not isinstance(top_n, (int, np.integer)) or top_n <= 0:
+        raise ValueError("top_n must be a positive integer.")
+    if not (np.isfinite(vip_threshold) and vip_threshold >= 0):
+        raise ValueError("vip_threshold must be a finite, non-negative number.")
+    if "VIP" not in vip.columns:
+        raise ValueError("vip must have a 'VIP' column.")
+
+    # Build a plotting copy so the caller's table is never mutated; feature
+    # names come from the index.
+    df = pd.DataFrame(
+        {
+            "feature": vip.index.astype(str),
+            "VIP": pd.to_numeric(vip["VIP"], errors="coerce").to_numpy(dtype=float),
+        }
+    )
+    df = df[np.isfinite(df["VIP"].to_numpy(dtype=float))]
+    if df.empty:
+        raise ValueError("No finite VIP values to plot.")
+
+    df = df.sort_values("VIP", ascending=False).head(int(top_n)).reset_index(drop=True)
+    # Order ascending so the largest VIP sits at the top after coord_flip.
+    order = df.sort_values("VIP", ascending=True)["feature"].tolist()
+    df["feature"] = pd.Categorical(df["feature"], categories=order, ordered=True)
+
+    thr_label = f"{vip_threshold:g}"
+    if color_by_threshold:
+        df["band"] = df["VIP"] >= vip_threshold
+        g = (
+                ggplot(df, aes("feature", "VIP", fill="band"))
+                + geom_col()
+                + scale_fill_manual(
+            values={False: "#9e9e9e", True: "#c0392b"},
+            labels=[f"< {thr_label}", f">= {thr_label}"],
+            name="VIP",
+        )
+        )
+    else:
+        g = ggplot(df, aes("feature", "VIP")) + geom_col(fill="#4c72b0")
+
+    g = (
+            g
+            + geom_hline(yintercept=vip_threshold, linetype="dashed", color="grey", size=0.4)
+            + coord_flip()
+            + labs(x="", y="VIP")
+            + theme_minimal(base_size=11)
+            + theme(plot_title=element_text(weight="bold", ha="center"))
+    )
+
+    if save_path:
+        Path(save_path).parent.mkdir(exist_ok=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            fig = g.draw()
+            fig.set_size_inches(*figsize)
+            fig.savefig(save_path, dpi=dpi, bbox_inches="tight")
+        plt.close(fig)
+    if show:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            print(g)
+
+    return g

--- a/lmsstat/plot/_plots.py
+++ b/lmsstat/plot/_plots.py
@@ -1257,7 +1257,7 @@ def plot_vip(
         top_n: int = 20,
         vip_threshold: float = 1.0,
         color_by_threshold: bool = True,
-        save_path: str | Path = "vip_plot.png",
+        save_path: str | Path | None = "vip_plot.png",
         dpi: int = 600,
         figsize: tuple = (8, 6),
         show: bool = False,
@@ -1280,6 +1280,9 @@ def plot_vip(
     vip_threshold : float
         Reference cutoff (finite, non-negative). Drawn as a dashed line; with
         ``color_by_threshold`` bars are split at ``VIP >= vip_threshold``.
+    save_path : str | Path | None
+        Where to save the PNG. If None, nothing is written and the ggplot is
+        returned for further use.
 
     Returns
     -------
@@ -1311,13 +1314,19 @@ def plot_vip(
 
     thr_label = f"{vip_threshold:g}"
     if color_by_threshold:
-        df["band"] = df["VIP"] >= vip_threshold
+        low, high = f"< {thr_label}", f">= {thr_label}"
+        # Explicit ordered categorical with both categories fixed, so the legend
+        # mapping is correct even when every shown feature is on one side.
+        df["band"] = pd.Categorical(
+            np.where(df["VIP"].to_numpy(dtype=float) >= vip_threshold, high, low),
+            categories=[low, high],
+            ordered=True,
+        )
         g = (
                 ggplot(df, aes("feature", "VIP", fill="band"))
                 + geom_col()
                 + scale_fill_manual(
-            values={False: "#9e9e9e", True: "#c0392b"},
-            labels=[f"< {thr_label}", f">= {thr_label}"],
+            values={low: "#9e9e9e", high: "#c0392b"},
             name="VIP",
         )
         )
@@ -1333,7 +1342,7 @@ def plot_vip(
             + theme(plot_title=element_text(weight="bold", ha="center"))
     )
 
-    if save_path:
+    if save_path is not None:
         Path(save_path).parent.mkdir(exist_ok=True)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -433,3 +433,8 @@ class TestPlotVip:
         g = plot_vip(_vip_df(), save_path=None)
         assert g is not None
         assert not (tmp_path / "vip_plot.png").exists()
+
+    def test_show_branch_runs(self):
+        # Smoke test for the interactive show=True branch (Agg backend).
+        g = plot_vip(_vip_df(n=5), save_path=None, show=True)
+        assert g is not None

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -12,6 +12,7 @@ from lmsstat.plot._plots import (
     plot_bar,
     plot_volcano,
     plot_correlation,
+    plot_vip,
     FOLDER,
 )
 from lmsstat.stat._allstat import allstats
@@ -346,3 +347,73 @@ class TestPlotCorrelation:
         cg = plot_correlation(two_group_data, out_path=None)
         assert isinstance(cg, ClusterGrid)
         assert not (tmp_path / "correlation_plot.png").exists()
+
+
+# ── plot_vip ──────────────────────────────────────────────────────────────
+
+def _vip_df(n=30, seed=0):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame(
+        {"VIP": rng.uniform(0.0, 3.0, n)},
+        index=[f"M{i:02d}" for i in range(n)],
+    )
+
+
+class TestPlotVip:
+    def test_returns_object_and_saves_png(self, tmp_path):
+        save = tmp_path / "vip.png"
+        g = plot_vip(_vip_df(), save_path=str(save))
+        assert g is not None
+        assert save.exists()
+        with open(save, "rb") as f:
+            assert f.read(4) == b"\x89PNG"
+
+    def test_top_n_limits_rows(self, tmp_path):
+        g = plot_vip(_vip_df(n=30), top_n=10, save_path=str(tmp_path / "v.png"))
+        assert len(g.data) == 10
+
+    def test_top_n_larger_than_n_shows_all(self, tmp_path):
+        g = plot_vip(_vip_df(n=8), top_n=50, save_path=str(tmp_path / "v.png"))
+        assert len(g.data) == 8
+
+    def test_selects_highest_vip(self, tmp_path):
+        df = pd.DataFrame({"VIP": [0.2, 2.5, 1.1, 0.9]}, index=["a", "b", "c", "d"])
+        g = plot_vip(df, top_n=2, save_path=str(tmp_path / "v.png"))
+        assert set(g.data["feature"]) == {"b", "c"}
+
+    def test_missing_vip_column_raises(self, tmp_path):
+        df = pd.DataFrame({"score": [1.0, 2.0]}, index=["a", "b"])
+        with pytest.raises(ValueError):
+            plot_vip(df, save_path=str(tmp_path / "v.png"))
+
+    def test_invalid_top_n_raises(self, tmp_path):
+        for bad in (0, -3, 2.5):
+            with pytest.raises((ValueError, TypeError)):
+                plot_vip(_vip_df(), top_n=bad, save_path=str(tmp_path / "v.png"))
+
+    def test_non_finite_vip_dropped(self, tmp_path):
+        df = pd.DataFrame({"VIP": [2.0, np.nan, np.inf, 1.0]}, index=["a", "b", "c", "d"])
+        g = plot_vip(df, save_path=str(tmp_path / "v.png"))
+        assert set(g.data["feature"]) == {"a", "d"}
+
+    def test_all_non_finite_raises(self, tmp_path):
+        df = pd.DataFrame({"VIP": [np.nan, np.inf]}, index=["a", "b"])
+        with pytest.raises(ValueError):
+            plot_vip(df, save_path=str(tmp_path / "v.png"))
+
+    def test_invalid_threshold_raises(self, tmp_path):
+        for bad in (-1.0, np.nan, np.inf):
+            with pytest.raises(ValueError):
+                plot_vip(_vip_df(), vip_threshold=bad, save_path=str(tmp_path / "v.png"))
+
+    def test_input_not_mutated(self, tmp_path):
+        df = _vip_df()
+        before = df.copy(deep=True)
+        _ = plot_vip(df, save_path=str(tmp_path / "v.png"))
+        pd.testing.assert_frame_equal(df, before)
+
+    def test_consumes_plsda_vip_table(self, two_group_data, tmp_path):
+        from lmsstat.plot._utils import plsda
+        *_, vip_df = plsda(two_group_data, n_components=2)
+        g = plot_vip(vip_df, save_path=str(tmp_path / "v.png"))
+        assert g is not None

--- a/tests/test_plot_plots.py
+++ b/tests/test_plot_plots.py
@@ -417,3 +417,19 @@ class TestPlotVip:
         *_, vip_df = plsda(two_group_data, n_components=2)
         g = plot_vip(vip_df, save_path=str(tmp_path / "v.png"))
         assert g is not None
+
+    def test_band_categories_preserved_all_above(self, tmp_path):
+        df = pd.DataFrame({"VIP": [1.5, 2.0, 3.0]}, index=["a", "b", "c"])
+        g = plot_vip(df, vip_threshold=1.0, save_path=str(tmp_path / "v.png"))
+        assert list(g.data["band"].cat.categories) == ["< 1", ">= 1"]
+
+    def test_band_categories_preserved_all_below(self, tmp_path):
+        df = pd.DataFrame({"VIP": [0.1, 0.2, 0.3]}, index=["a", "b", "c"])
+        g = plot_vip(df, vip_threshold=1.0, save_path=str(tmp_path / "v.png"))
+        assert list(g.data["band"].cat.categories) == ["< 1", ">= 1"]
+
+    def test_save_path_none_no_save(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        g = plot_vip(_vip_df(), save_path=None)
+        assert g is not None
+        assert not (tmp_path / "vip_plot.png").exists()


### PR DESCRIPTION
## Summary

Small visualization PR (keeping one PR in flight). Adds the plotting layer on top of the VIP scores PLS-DA already computes.

### `plot.plot_vip(vip, *, top_n=20, vip_threshold=1.0, color_by_threshold=True, save_path="vip_plot.png", dpi=600, figsize=(8,6), show=False)`
- **Pure consumer** of the VIP table (`vip_df`: feature index + `VIP` column) produced by PLS-DA / `plot_plsda(...)[4]`. Computes no statistics.
- Horizontal bar chart, highest VIP at top; returns the plotnine ggplot, saves PNG by default.
- Dashed line at `vip_threshold` (default 1.0); `color_by_threshold` splits bars at `VIP >= vip_threshold` with **neutral `VIP < t` / `>= t` labels** (not "important/significant").

### Review-hardening (as agreed in the spec)
- VIP numeric-coerced; **non-finite rows dropped**, `ValueError` if none remain.
- `top_n` must be a **positive integer**; if `>= n`, all features shown.
- `vip_threshold` must be **finite and non-negative**.
- **Input table never mutated** — feature names read from the index onto a plotting copy.

### Out of scope (separate PRs)
Per-component VIP, S-plot, loadings plot.

### Tests
11 new tests (return/save, top_n limit + overflow, highest-VIP selection, missing column, invalid top_n, non-finite VIP dropped / all-non-finite raise, invalid threshold, no-mutation, consumes a real `plsda()` table). Full suite **264 passing** locally (`lmsstat` conda env). Visually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

PLS-DA VIP 점수를 막대 그래프로 시각화하는 플로팅 유틸리티를 추가하고, 그 사용 방법을 문서화합니다.

New Features:
- PLS-DA VIP 테이블로부터 가로 막대 그래프를 렌더링하는 `plot_vip`를 도입하고, 표시할 특성 개수와 VIP 임계값을 설정 가능하도록 합니다.

Enhancements:
- 원본 DataFrame을 변경하지 않으면서 견고한 동작을 보장하기 위해, `plot_vip`에 대한 VIP 입력값과 임계값을 검증합니다.

Documentation:
- 새로운 VIP 플로팅 함수에 대한 문서를 추가하고, PLS-DA VIP 테이블과 함께 `plot_vip`를 사용하는 예제를 제공합니다.

Tests:
- 파일 출력, 행 개수 제한, VIP 선택, 잘못된 입력, 비유한(non-finite) 값 처리, 그리고 plsda가 생성한 VIP 테이블과의 호환성을 포함해 `plot_vip` 동작을 검증하는 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a plotting utility to visualize PLS-DA VIP scores as a bar chart and document its usage.

New Features:
- Introduce plot_vip to render a horizontal bar chart from a PLS-DA VIP table with configurable feature count and VIP threshold.

Enhancements:
- Validate VIP inputs and thresholds for plot_vip to ensure robust behavior without mutating the source DataFrame.

Documentation:
- Document the new VIP plotting function and provide an example of using plot_vip with the PLS-DA VIP table.

Tests:
- Add tests covering plot_vip behavior, including file output, row limiting, VIP selection, invalid inputs, non-finite handling, and compatibility with plsda-generated VIP tables.

</details>