### PR TITLE
Add QC/RSD feature filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ data = stat.rsd_filter(data, qc_label="QC", max_rsd=30)
 # inspect what was dropped:
 # data, rsd = stat.rsd_filter(data, qc_label="QC", max_rsd=30, return_rsd=True)
 
+# rsd_filter keeps the QC rows (they were only used to compute %RSD). Drop them
+# before downstream analysis so QC is not treated as an analysis group by
+# allstats / PCA / PLS-DA / volcano:
+data = data[data["Group"] != "QC"].reset_index(drop=True)
+
 # Missing-value imputation: "half_min" (LC-MS below-LOD), "min", or "knn"
 data = stat.impute_missing(data, method="half_min")
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ from lmsstat import stat
 
 data = pd.read_csv("data.csv")
 
+# QC/RSD feature filtering: drop features whose %RSD across the QC samples
+# (Group == qc_label) exceeds max_rsd. Filters features only; samples untouched.
+data = stat.rsd_filter(data, qc_label="QC", max_rsd=30)
+# inspect what was dropped:
+# data, rsd = stat.rsd_filter(data, qc_label="QC", max_rsd=30, return_rsd=True)
+
 # Missing-value imputation: "half_min" (LC-MS below-LOD), "min", or "knn"
 data = stat.impute_missing(data, method="half_min")
 
@@ -79,8 +85,9 @@ data = stat.normalize(data, method="pqn")
 data = stat.log_transform(data, base=2, offset=1.0)
 ```
 
-A typical order is impute → normalize → log transform → `scaling`, after which
-`allstats`, volcano/PLS-DA, and the heatmap operate on cleaner inputs.
+A typical order is QC/RSD filter → impute → normalize → log transform →
+`scaling`, after which `allstats`, volcano/PLS-DA, and the heatmap operate on
+cleaner inputs.
 
 ### PCA
 

--- a/lmsstat/stat/__init__.py
+++ b/lmsstat/stat/__init__.py
@@ -1,6 +1,6 @@
 from ._allstat import allstats
 from ._effect import effect_size_table
 from ._posthoc import dunn_test, scheffe_test, games_howell_test
-from ._preprocess import impute_missing, log_transform, normalize
+from ._preprocess import impute_missing, log_transform, normalize, rsd_filter
 from ._utils import preprocess_data, p_adjust, correlation, scaling
 from ._tests import t_test, u_test, anova_test, kruskal_test, norm_test

--- a/lmsstat/stat/_preprocess.py
+++ b/lmsstat/stat/_preprocess.py
@@ -177,7 +177,13 @@ def normalize(data: pd.DataFrame, method: str = "median") -> pd.DataFrame:
     return _reassemble(data, numeric)
 
 
-def rsd_filter(data, *, qc_label="QC", max_rsd=30.0, return_rsd=False):
+def rsd_filter(
+        data: pd.DataFrame,
+        *,
+        qc_label: str = "QC",
+        max_rsd: float = 30.0,
+        return_rsd: bool = False,
+):
     """
     Drop features whose %RSD across the QC samples exceeds ``max_rsd``.
 

--- a/lmsstat/stat/_preprocess.py
+++ b/lmsstat/stat/_preprocess.py
@@ -175,3 +175,69 @@ def normalize(data: pd.DataFrame, method: str = "median") -> pd.DataFrame:
 
     numeric = pd.DataFrame(Xn, columns=numeric.columns, index=numeric.index)
     return _reassemble(data, numeric)
+
+
+def rsd_filter(data, *, qc_label="QC", max_rsd=30.0, return_rsd=False):
+    """
+    Drop features whose %RSD across the QC samples exceeds ``max_rsd``.
+
+    %RSD (a.k.a. CV) is the standard LC-MS quality metric for feature
+    reliability: ``100 * std(ddof=1) / mean`` computed over the pooled QC
+    samples. Only features (columns) are filtered; samples are untouched.
+
+    Parameters
+    ----------
+    data : DataFrame
+        Wide table. Col0 = Sample, Col1 = Group, remaining = features. Expects
+        raw, non-negative intensities.
+    qc_label : str
+        Group label that marks the QC (pooled) samples. Defaults to "QC".
+    max_rsd : float
+        %RSD cutoff (finite, non-negative). Features with QC %RSD <= max_rsd
+        are kept.
+    return_rsd : bool
+        If True, also return a Series of the QC %RSD for *all* original
+        features (so the caller can see what was dropped).
+
+    Returns
+    -------
+    DataFrame, or (DataFrame, Series) when ``return_rsd=True``.
+
+    Notes
+    -----
+    A feature is dropped (treated as infinite %RSD) when it cannot be assessed:
+    fewer than two finite QC values, or a non-positive QC mean. A constant QC
+    feature (zero spread, positive mean) has 0% RSD and is kept. Requires at
+    least two QC samples.
+    """
+    if not (np.isfinite(max_rsd) and max_rsd >= 0):
+        raise ValueError("max_rsd must be a finite, non-negative number.")
+
+    data, numeric = _split(data)
+    qc_mask = (data["Group"].astype(str) == str(qc_label)).to_numpy()
+    n_qc = int(qc_mask.sum())
+    if n_qc < 2:
+        raise ValueError(
+            f"rsd_filter needs at least two QC samples labelled {qc_label!r}; "
+            f"found {n_qc}."
+        )
+
+    qc_arr = numeric.to_numpy(dtype=float)[qc_mask]
+    n_finite = np.sum(np.isfinite(qc_arr), axis=0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        mean = np.nanmean(qc_arr, axis=0)
+        std = np.nanstd(qc_arr, axis=0, ddof=1)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            rsd = 100.0 * std / mean
+    # Unassessable features → infinite %RSD (always dropped).
+    degenerate = (n_finite < 2) | ~np.isfinite(mean) | (mean <= 0) | np.isnan(rsd)
+    rsd = np.where(degenerate, np.inf, rsd)
+
+    rsd_series = pd.Series(rsd, index=numeric.columns, name="rsd")
+    keep = numeric.columns[rsd <= max_rsd]
+    filtered = _reassemble(data, numeric[keep])
+
+    if return_rsd:
+        return filtered, rsd_series
+    return filtered

--- a/tests/test_stat_preprocess.py
+++ b/tests/test_stat_preprocess.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from lmsstat.stat._preprocess import impute_missing, log_transform, normalize
+from lmsstat.stat._preprocess import impute_missing, log_transform, normalize, rsd_filter
 
 
 @pytest.fixture()
@@ -317,3 +317,97 @@ class TestNormalize:
     def test_invalid_method_raises(self, simple_data):
         with pytest.raises(ValueError):
             normalize(simple_data, method="bogus")
+
+
+# ── rsd_filter ──────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def qc_data():
+    # QC %RSD per feature (over the 3 QC rows):
+    #   Met_0: [10,12,8]   -> mean 10, sd 2  -> 20%
+    #   Met_1: [100,100,100] -> constant     -> 0%
+    #   Met_2: [1,5,9]     -> mean 5,  sd 4  -> 80%
+    return pd.DataFrame(
+        {
+            "Sample": [f"S{i}" for i in range(9)],
+            "Group": ["QC", "QC", "QC", "A", "A", "A", "B", "B", "B"],
+            "Met_0": [10.0, 12.0, 8.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "Met_1": [100.0, 100.0, 100.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "Met_2": [1.0, 5.0, 9.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        }
+    )
+
+
+class TestRsdFilter:
+    def test_keeps_and_drops_by_threshold(self, qc_data):
+        out = rsd_filter(qc_data, max_rsd=30.0)
+        assert list(out.columns) == ["Sample", "Group", "Met_0", "Met_1"]  # Met_2 (80%) dropped
+        assert out.shape[0] == qc_data.shape[0]  # samples untouched
+
+    def test_constant_qc_feature_kept(self, qc_data):
+        out = rsd_filter(qc_data, max_rsd=30.0)
+        assert "Met_1" in out.columns  # 0% RSD
+
+    def test_return_rsd_series(self, qc_data):
+        out, rsd = rsd_filter(qc_data, max_rsd=30.0, return_rsd=True)
+        assert list(rsd.index) == ["Met_0", "Met_1", "Met_2"]  # all original features
+        assert rsd["Met_0"] == pytest.approx(20.0)
+        assert rsd["Met_1"] == pytest.approx(0.0)
+        assert rsd["Met_2"] == pytest.approx(80.0)
+
+    def test_preserves_sample_group_and_order(self, qc_data):
+        out = rsd_filter(qc_data, max_rsd=200.0)  # keep everything
+        assert list(out.columns) == list(qc_data.columns)
+        assert out["Sample"].tolist() == qc_data["Sample"].tolist()
+        assert out["Group"].tolist() == qc_data["Group"].tolist()
+
+    def test_does_not_mutate_input(self, qc_data):
+        before = qc_data.copy(deep=True)
+        _ = rsd_filter(qc_data, max_rsd=30.0)
+        pd.testing.assert_frame_equal(qc_data, before)
+
+    def test_missing_qc_label_raises(self, qc_data):
+        with pytest.raises(ValueError):
+            rsd_filter(qc_data, qc_label="POOL")
+
+    def test_fewer_than_two_qc_raises(self):
+        df = pd.DataFrame(
+            {"Sample": ["q", "a", "b"], "Group": ["QC", "A", "B"],
+             "Met_0": [10.0, 1.0, 2.0]}
+        )
+        with pytest.raises(ValueError):
+            rsd_filter(df)
+
+    @pytest.mark.parametrize("bad", [-1.0, np.nan, np.inf])
+    def test_invalid_max_rsd_raises(self, qc_data, bad):
+        with pytest.raises(ValueError):
+            rsd_filter(qc_data, max_rsd=bad)
+
+    def test_qc_nonpositive_mean_dropped(self):
+        df = pd.DataFrame(
+            {"Sample": [f"S{i}" for i in range(6)],
+             "Group": ["QC", "QC", "QC", "A", "A", "B"],
+             "Met_0": [-1.0, -2.0, -3.0, 1.0, 2.0, 3.0]}  # QC mean -2 -> dropped
+        )
+        out = rsd_filter(df, max_rsd=30.0)
+        assert "Met_0" not in out.columns
+
+    def test_nan_tolerant(self):
+        df = pd.DataFrame(
+            {"Sample": [f"S{i}" for i in range(4)],
+             "Group": ["QC", "QC", "QC", "A"],
+             "Met_0": [10.0, 12.0, np.nan, 5.0],   # QC [10,12] -> ~12.9% -> keep
+             "Met_1": [10.0, np.nan, np.nan, 5.0]}  # only 1 finite QC -> dropped
+        )
+        out = rsd_filter(df, max_rsd=30.0)
+        assert "Met_0" in out.columns
+        assert "Met_1" not in out.columns
+
+    def test_all_features_dropped_returns_empty_features(self):
+        df = pd.DataFrame(
+            {"Sample": ["q1", "q2", "a", "b"], "Group": ["QC", "QC", "A", "B"],
+             "M0": [1.0, 9.0, 2.0, 3.0], "M1": [2.0, 18.0, 2.0, 3.0]}  # QC RSD ~113%
+        )
+        out = rsd_filter(df, max_rsd=5.0)
+        assert list(out.columns) == ["Sample", "Group"]
+        assert out.shape[0] == 4


### PR DESCRIPTION
## Summary

`stat`-layer QC step. `stat.rsd_filter` drops unreliable features by their %RSD across the pooled QC samples — the standard LC-MS quality filter. Lives in `stat/_preprocess.py` alongside impute/normalize/log and reuses the same contract.

### `stat.rsd_filter(data, *, qc_label="QC", max_rsd=30.0, return_rsd=False)`
- %RSD = `100 * std(ddof=1) / mean` over the QC rows (`Group == qc_label`), per feature. Keeps features with `%RSD <= max_rsd`. **Feature filtering only — samples untouched.**
- Same preprocessing contract: never mutates input; preserves `Sample`/`Group` and original feature order.
- `return_rsd=True` also returns the %RSD Series for **all** original features (transparency on what was dropped).

### Decisions (as agreed)
- **Requires ≥ 2 QC samples** → `ValueError` otherwise. Raises on missing `qc_label` or invalid `max_rsd` (negative / non-finite).
- **Unassessable feature → dropped** (treated as infinite %RSD): `< 2` finite QC values, or non-positive QC mean. Expects raw non-negative intensities (documented).
- **Constant QC feature** (zero spread, positive mean) → `0%` → **kept**.
- **All features dropped → empty-feature frame** (permissive; no error), per your pick.

### Tests
13 new tests: exact keep/drop on known %RSD (20/0/80%), constant-QC kept, `return_rsd` series, missing `qc_label` raises, `<2` QC raises, invalid `max_rsd` raises, QC mean ≤ 0 dropped, NaN-tolerant (partial computes / `<2` finite dropped), no-mutation + order, all-dropped empty frame. Full suite **281 passing** locally (`lmsstat` conda env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

다운스트림 전처리 및 분석 이전 단계에서 신뢰도가 낮은 LC-MS 피처를 제거하기 위해 QC 기반 %RSD 피처 필터링을 도입합니다.

새로운 기능:
- 샘플과 메타데이터를 보존하면서 QC %RSD가 설정 가능한 임계값을 초과하는 피처를 제거하기 위한 `stat.rsd_filter`를 추가합니다.
- 전처리 파이프라인에서 사용할 수 있도록 공개 `stat` API에 `rsd_filter`를 노출합니다.

문서:
- README에 `rsd_filter` 사용법과 전처리 순서 내에서의 일반적인 배치 위치를 문서화합니다.

테스트:
- 유지/제거 임계값, 상수 피처, NaN 처리, 오류 조건, 0 이하 평균값, 모든 피처가 제거되는 시나리오 등을 포함하여 `rsd_filter` 동작을 검증하는 단위 테스트를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce QC-based %RSD feature filtering to drop unreliable LC-MS features before downstream preprocessing and analysis.

New Features:
- Add stat.rsd_filter to remove features whose QC %RSD exceeds a configurable threshold while preserving samples and metadata.
- Expose rsd_filter in the public stat API for use in preprocessing pipelines.

Documentation:
- Document rsd_filter usage and typical placement in the preprocessing order in the README.

Tests:
- Add unit tests covering rsd_filter behavior, including keep/drop thresholds, constant features, NaN handling, error conditions, nonpositive means, and all-features-dropped scenarios.

</details>